### PR TITLE
fix: slicing of SQL for tty error reporting

### DIFF
--- a/src/snapshots/squawk__reporter__test_reporter__display_violations_tty.snap
+++ b/src/snapshots/squawk__reporter__test_reporter__display_violations_tty.snap
@@ -4,7 +4,7 @@ expression: "strip_ansi_codes(&String::from_utf8_lossy(&buff))"
 ---
 main.sql:1:0: warning: adding-not-nullable-field
 
-   1 | 
+   1 |  
    2 |    ALTER TABLE "core_recipe" ADD COLUMN "foo" integer NOT NULL;
 
   note: Adding a NOT NULL field requires exclusive locks and table rewrites.

--- a/src/snapshots/squawk__reporter__test_reporter__span_offsets.snap
+++ b/src/snapshots/squawk__reporter__test_reporter__span_offsets.snap
@@ -1,6 +1,6 @@
 ---
 source: src/reporter.rs
-expression: "pretty_violations(violations, &sql, filename)"
+expression: "pretty_violations(violations, sql, filename)"
 ---
 [
     ReportViolation {
@@ -17,7 +17,7 @@ expression: "pretty_violations(violations, &sql, filename)"
             ),
         ],
         rule_name: AddingNotNullableField,
-        sql: "\n   ALTER TABLE \"core_recipe\" ADD COLUMN \"foo\" integer NOT NULL;",
+        sql: "   ALTER TABLE \"core_recipe\" ADD COLUMN \"foo\" integer NOT NULL;",
     },
     ReportViolation {
         file: "main.sql",


### PR DESCRIPTION
We weren't slicing the SQL for the pretty errors correctly resulting in
the first char being cut off in some cases.