### PR TITLE
ref: stdin to be automatically detected instead of using `-` as path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,7 @@ dependencies = [
 name = "squawk"
 version = "0.1.3"
 dependencies = [
+ "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_repr = "0.1"
 structopt = "0.3"
 console = "0.11.3"
 lazy_static = "1.4.0"
+atty = "0.2"
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -61,12 +61,12 @@ pub fn dump_ast_for_paths<W: io::Write>(
     let mut process_dump_ast = |sql: &str| -> Result<(), DumpAstError> {
         match dump_ast {
             DumpAstOption::Raw => {
-                let json_ast = parse_sql_query_json(&sql)?;
+                let json_ast = parse_sql_query_json(sql)?;
                 let json_str = serde_json::to_string(&json_ast)?;
                 writeln!(f, "{}", json_str)?;
             }
             DumpAstOption::Parsed => {
-                let ast = parse_sql_query(&sql)?;
+                let ast = parse_sql_query(sql)?;
                 let ast_str = serde_json::to_string(&ast)?;
                 writeln!(f, "{}", ast_str)?;
             }
@@ -120,7 +120,7 @@ pub fn check_files<W: io::Write>(
         if !violations.is_empty() {
             found_errors = true;
         }
-        print_violations(f, &pretty_violations(violations, &sql, path), &reporter)?;
+        print_violations(f, &pretty_violations(violations, sql, path), &reporter)?;
         Ok(found_errors)
     };
 
@@ -132,7 +132,7 @@ pub fn check_files<W: io::Write>(
 
     for path in paths {
         let sql = get_sql_from_path(path)?;
-        found_errors = process_violations(&sql, &path)?;
+        found_errors = process_violations(&sql, path)?;
     }
     Ok(found_errors)
 }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -14,9 +14,6 @@ use structopt::clap::arg_enum;
 use structopt::StructOpt;
 
 fn get_sql_from_path(path: &str) -> Option<String> {
-    if path == "-" {
-        return get_sql_from_stdin().ok();
-    }
     if let Ok(mut file) = File::open(path) {
         let mut contents = String::new();
         file.read_to_string(&mut contents).ok().map(|_| contents)
@@ -61,22 +58,34 @@ impl std::convert::From<serde_json::error::Error> for DumpAstError {
 pub fn dump_ast_for_paths<W: io::Write>(
     f: &mut W,
     paths: &[String],
+    is_stdin: bool,
     dump_ast: DumpAstOption,
 ) -> Result<(), DumpAstError> {
+    let mut process_dump_ast = |sql: &str| -> Result<(), DumpAstError> {
+        match dump_ast {
+            DumpAstOption::Raw => {
+                let json_ast = parse_sql_query_json(&sql)?;
+                let json_str = serde_json::to_string(&json_ast)?;
+                writeln!(f, "{}", json_str)?;
+            }
+            DumpAstOption::Parsed => {
+                let ast = parse_sql_query(&sql)?;
+                let ast_str = serde_json::to_string(&ast)?;
+                writeln!(f, "{}", ast_str)?;
+            }
+        }
+        Ok(())
+    };
+    if is_stdin {
+        if let Ok(sql) = get_sql_from_stdin() {
+            process_dump_ast(&sql)?;
+        }
+        return Ok(());
+    }
+
     for path in paths {
         if let Some(sql) = get_sql_from_path(path) {
-            match dump_ast {
-                DumpAstOption::Raw => {
-                    let json_ast = parse_sql_query_json(&sql)?;
-                    let json_str = serde_json::to_string(&json_ast)?;
-                    writeln!(f, "{}", json_str)?;
-                }
-                DumpAstOption::Parsed => {
-                    let ast = parse_sql_query(&sql)?;
-                    let ast_str = serde_json::to_string(&ast)?;
-                    writeln!(f, "{}", ast_str)?;
-                }
-            }
+            process_dump_ast(&sql)?;
         }
     }
     Ok(())
@@ -103,19 +112,33 @@ impl std::convert::From<CheckSQLError> for CheckFilesError {
 pub fn check_files<W: io::Write>(
     f: &mut W,
     paths: &[String],
+    is_stdin: bool,
     reporter: Reporter,
     excluded_rules: Option<Vec<String>>,
 ) -> Result<bool, CheckFilesError> {
     let mut found_errors = false;
     let excluded_rules = excluded_rules.unwrap_or_else(|| vec![]);
+
+    let mut process_violations = |sql: &str, path: &str| -> Result<bool, CheckFilesError> {
+        let mut found_errors = false;
+        let violations = check_sql(sql, &excluded_rules)?;
+        if !violations.is_empty() {
+            found_errors = true;
+        }
+        print_violations(f, &pretty_violations(violations, &sql, path), &reporter)?;
+        Ok(found_errors)
+    };
+
+    if is_stdin {
+        if let Ok(sql) = get_sql_from_stdin() {
+            found_errors = process_violations(&sql, "stdin")?;
+        }
+        return Ok(found_errors);
+    }
+
     for path in paths {
         if let Some(sql) = get_sql_from_path(path) {
-            let violations = check_sql(&sql, &excluded_rules)?;
-            if !violations.is_empty() {
-                found_errors = true
-            }
-            let filename = if path == "-" { "stdin" } else { &path };
-            print_violations(f, &pretty_violations(violations, &sql, filename), &reporter)?;
+            found_errors = process_violations(&sql, &path)?;
         }
     }
     Ok(found_errors)

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -13,13 +13,10 @@ use std::io::prelude::*;
 use structopt::clap::arg_enum;
 use structopt::StructOpt;
 
-fn get_sql_from_path(path: &str) -> Option<String> {
-    if let Ok(mut file) = File::open(path) {
-        let mut contents = String::new();
-        file.read_to_string(&mut contents).ok().map(|_| contents)
-    } else {
-        None
-    }
+fn get_sql_from_path(path: &str) -> Result<String, std::io::Error> {
+    let mut file = File::open(path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).map(|_| contents)
 }
 
 arg_enum! {
@@ -77,16 +74,14 @@ pub fn dump_ast_for_paths<W: io::Write>(
         Ok(())
     };
     if is_stdin {
-        if let Ok(sql) = get_sql_from_stdin() {
-            process_dump_ast(&sql)?;
-        }
+        let sql = get_sql_from_stdin()?;
+        process_dump_ast(&sql)?;
         return Ok(());
     }
 
     for path in paths {
-        if let Some(sql) = get_sql_from_path(path) {
-            process_dump_ast(&sql)?;
-        }
+        let sql = get_sql_from_path(path)?;
+        process_dump_ast(&sql)?;
     }
     Ok(())
 }
@@ -130,16 +125,14 @@ pub fn check_files<W: io::Write>(
     };
 
     if is_stdin {
-        if let Ok(sql) = get_sql_from_stdin() {
-            found_errors = process_violations(&sql, "stdin")?;
-        }
+        let sql = get_sql_from_stdin()?;
+        found_errors = process_violations(&sql, "stdin")?;
         return Ok(found_errors);
     }
 
     for path in paths {
-        if let Some(sql) = get_sql_from_path(path) {
-            found_errors = process_violations(&sql, &path)?;
-        }
+        let sql = get_sql_from_path(path)?;
+        found_errors = process_violations(&sql, &path)?;
     }
     Ok(found_errors)
 }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -399,7 +399,7 @@ lazy_static! {
                 ViolationMessage::Note(
                     "Creating an index blocks writes.".into()
                 ),
-                ViolationMessage::Note(
+                ViolationMessage::Help(
                     "Create the index CONCURRENTLY.".into()
                 ),
             ],

--- a/src/snapshots/squawk__rules__test_rules__adding_index_non_concurrently.snap
+++ b/src/snapshots/squawk__rules__test_rules__adding_index_non_concurrently.snap
@@ -1,6 +1,6 @@
 ---
 source: src/rules.rs
-expression: "check_sql(&bad_sql, &[])"
+expression: "check_sql(bad_sql, &[])"
 ---
 Ok(
     [
@@ -16,7 +16,7 @@ Ok(
                 Note(
                     "Creating an index blocks writes.",
                 ),
-                Note(
+                Help(
                     "Create the index CONCURRENTLY.",
                 ),
             ],


### PR DESCRIPTION
Previously stdin wasn't detected and was assumed when `-` was used as
a path.

Now we use atty to check.