### PR TITLE
update(bot): subcommand to use bot name instead of id

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -174,7 +174,7 @@ pub fn comment_on_pr(
     private_key: &str,
     app_id: i64,
     install_id: i64,
-    bot_id: i64,
+    bot_name: &str,
     pr: PullRequest,
     comment_body: String,
 ) -> Result<Value, GithubError> {
@@ -182,7 +182,12 @@ pub fn comment_on_pr(
     let access_token = create_access_token(&jwt, install_id)?;
     let comments = list_comments(&pr, &access_token.token)?;
 
-    match comments.iter().find(|x| x.user.id == bot_id) {
+    let bot_name = format!("{}[bot]", bot_name);
+
+    match comments
+        .iter()
+        .find(|x| x.user.r#type == "Bot" && x.user.login == bot_name)
+    {
         Some(prev_comment) => update_comment(
             &pr.owner,
             &pr.repo,

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -40,9 +40,9 @@ pub enum Command {
         /// GitHub Install Id. The installation that squawk is acting on.
         #[structopt(long, env = "GITHUB_INSTALL_ID")]
         github_install_id: i64,
-        /// GitHub Bot Id. The User id of the bot.
-        #[structopt(long, env = "GITHUB_BOT_ID")]
-        github_bot_id: i64,
+        /// GitHub Bot Name.
+        #[structopt(long, env = "GITHUB_BOT_NAME")]
+        github_bot_name: String,
         /// GitHub Repo Owner
         /// github.com/sbdchd/squawk, sbdchd is the owner
         #[structopt(long, env = "GITHUB_REPO_OWNER")]
@@ -65,7 +65,7 @@ pub fn check_and_comment_on_pr(cmd: Command, is_stdin: bool) -> Result<i32, Squa
         github_private_key,
         github_app_id,
         github_install_id,
-        github_bot_id,
+        github_bot_name,
         github_repo_owner,
         github_repo_name,
         github_pr_number,
@@ -82,7 +82,7 @@ pub fn check_and_comment_on_pr(cmd: Command, is_stdin: bool) -> Result<i32, Squa
         &github_private_key,
         github_app_id,
         github_install_id,
-        github_bot_id,
+        &github_bot_name,
         pr,
         comment_body,
     )?;


### PR DESCRIPTION
Getting the bot id was pretty manually, instead we can use the bot name
instead.