### PR TITLE
ref(upload-to-github): prefix env vars with SQUAWK_

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ name = "squawk"
 version = "0.1.4"
 dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonwebtoken 7.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ lazy_static = "1.4.0"
 atty = "0.2"
 reqwest = "0.9.18"
 jsonwebtoken = "7"
+base64 = "0.12.2"
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/src/github.rs
+++ b/src/github.rs
@@ -28,7 +28,7 @@ pub struct GithubAccessToken {
 
 /// https://developer.github.com/v3/apps/#create-an-installation-access-token-for-an-app
 fn create_access_token(jwt: &str, install_id: i64) -> Result<GithubAccessToken, GithubError> {
-    reqwest::Client::new()
+    Ok(reqwest::Client::new()
         .post(&format!(
             "https://api.github.com/app/installations/{install_id}/access_tokens",
             install_id = install_id
@@ -37,14 +37,13 @@ fn create_access_token(jwt: &str, install_id: i64) -> Result<GithubAccessToken, 
         .header(ACCEPT, "application/vnd.github.machine-man-preview+json")
         .send()?
         .error_for_status()?
-        .json::<GithubAccessToken>()
-        .map_err(|e| e.into())
+        .json::<GithubAccessToken>()?)
 }
 
 /// https://developer.github.com/v3/issues/comments/#create-an-issue-comment
 fn create_comment(comment: CommentArgs, secret: &str) -> Result<Value, GithubError> {
     let comment_body = CommentBody { body: comment.body };
-    reqwest::Client::new()
+    Ok(reqwest::Client::new()
         .post(&format!(
             "https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/comments",
             owner = comment.owner,
@@ -55,8 +54,7 @@ fn create_comment(comment: CommentArgs, secret: &str) -> Result<Value, GithubErr
         .json(&comment_body)
         .send()?
         .error_for_status()?
-        .json::<Value>()
-        .map_err(|e| e.into())
+        .json::<Value>()?)
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -130,7 +128,7 @@ fn generate_jwt(
 fn list_comments(pr: &PullRequest, secret: &str) -> Result<Vec<Comment>, GithubError> {
     // TODO(sbdchd): use the next links to get _all_ the comments
     // see: https://developer.github.com/v3/guides/traversing-with-pagination/
-    reqwest::Client::new()
+    Ok(reqwest::Client::new()
         .get(&format!(
             "https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/comments",
             owner = pr.owner,
@@ -141,8 +139,7 @@ fn list_comments(pr: &PullRequest, secret: &str) -> Result<Vec<Comment>, GithubE
         .header(AUTHORIZATION, format!("Bearer {}", secret))
         .send()?
         .error_for_status()?
-        .json::<Vec<Comment>>()
-        .map_err(|e| e.into())
+        .json::<Vec<Comment>>()?)
 }
 
 /// https://developer.github.com/v3/issues/comments/#update-an-issue-comment
@@ -153,7 +150,7 @@ fn update_comment(
     body: String,
     secret: &str,
 ) -> Result<Value, GithubError> {
-    reqwest::Client::new()
+    Ok(reqwest::Client::new()
         .patch(&format!(
             "https://api.github.com/repos/{owner}/{repo}/issues/comments/{comment_id}",
             owner = owner,
@@ -164,8 +161,7 @@ fn update_comment(
         .json(&CommentBody { body })
         .send()?
         .error_for_status()?
-        .json::<Value>()
-        .map_err(|e| e.into())
+        .json::<Value>()?)
 }
 
 pub struct PullRequest {


### PR DESCRIPTION
Also add new option for passing the github private key as base64 which
makes adding it to CI a bit easier.

minor styling changes to mapping errors into the respective types.