### PR TITLE
add(cli): --stdin-filepath argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,9 @@ struct Opt {
     /// Style of error reporting
     #[structopt(long, possible_values = &Reporter::variants(), case_insensitive = true)]
     reporter: Option<Reporter>,
+    #[structopt(long)]
+    /// Path to use in reporting for stdin
+    stdin_filepath: Option<String>,
     #[structopt(subcommand)]
     cmd: Option<Command>,
 }
@@ -62,7 +65,7 @@ fn main() {
 
     let is_stdin = !atty::is(Stream::Stdin);
     if let Some(subcommand) = opts.cmd {
-        match check_and_comment_on_pr(subcommand, is_stdin) {
+        match check_and_comment_on_pr(subcommand, is_stdin, opts.stdin_filepath) {
             Ok(_) => process::exit(0),
             Err(err) => {
                 eprintln!("{:#?}", err);
@@ -78,7 +81,7 @@ fn main() {
                 dump_ast_kind,
             ));
         } else {
-            match check_files(&opts.paths, is_stdin, opts.exclude) {
+            match check_files(&opts.paths, is_stdin, opts.stdin_filepath, opts.exclude) {
                 Ok(file_reports) => {
                     let reporter = opts.reporter.unwrap_or(Reporter::Tty);
                     let total_violations = file_reports

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -108,6 +108,7 @@ impl std::convert::From<CheckSQLError> for CheckFilesError {
 pub fn check_files(
     paths: &[String],
     is_stdin: bool,
+    stdin_path: Option<String>,
     excluded_rules: Option<Vec<String>>,
 ) -> Result<Vec<ViolationContent>, CheckFilesError> {
     let excluded_rules = excluded_rules.unwrap_or_else(|| vec![]);
@@ -122,7 +123,8 @@ pub fn check_files(
 
     if is_stdin {
         let sql = get_sql_from_stdin()?;
-        process_violations(&sql, "stdin")?;
+        let path = stdin_path.unwrap_or_else(|| "stdin".into());
+        process_violations(&sql, &path)?;
     }
 
     for path in paths {

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -90,7 +90,11 @@ fn get_github_private_key(
     }
 }
 
-pub fn check_and_comment_on_pr(cmd: Command, is_stdin: bool) -> Result<Value, SquawkError> {
+pub fn check_and_comment_on_pr(
+    cmd: Command,
+    is_stdin: bool,
+    stdin_path: Option<String>,
+) -> Result<Value, SquawkError> {
     let Command::UploadToGithub {
         paths,
         exclude,
@@ -103,7 +107,7 @@ pub fn check_and_comment_on_pr(cmd: Command, is_stdin: bool) -> Result<Value, Sq
         github_pr_number,
         github_private_key_base64,
     } = cmd;
-    let violations = check_files(&paths, is_stdin, exclude)?;
+    let violations = check_files(&paths, is_stdin, stdin_path, exclude)?;
     let comment_body = get_comment_body(violations);
     let pr = PullRequest {
         issue: github_pr_number,


### PR DESCRIPTION
When wrapping squawk it can be easier to use stdin. Instead of only
using `stdin` as the filename this extra argument allows users to specify
a name to use in the error reporting.