### PR TITLE
add: logging, mainly around upload-to-github

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplelog"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,10 +1418,12 @@ dependencies = [
  "jsonwebtoken 7.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libpg_query-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_repr 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2082,6 +2094,7 @@ dependencies = [
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum serde_yaml 0.8.12 (registry+https://github.com/rust-lang/crates.io-index)" = "16c7a592a1ec97c9c1c68d75b6e537dcbf60c7618e038e7841e00af1d9ccf0c4"
 "checksum simple_asn1 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b25ecba7165254f0c97d6c22a64b1122a03634b18d20a34daf21e18f892e618"
+"checksum simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2b2736f58087298a448859961d3f4a0850b832e72619d75adc69da7993c2cd3c"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ atty = "0.2"
 reqwest = "0.9.18"
 jsonwebtoken = "7"
 base64 = "0.12.2"
+simplelog = "0.8.0"
+log = "0.4.8"
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crate::reporter::{
 };
 use crate::subcommand::{check_and_comment_on_pr, Command};
 use atty::Stream;
+use simplelog::CombinedLogger;
 use std::io;
 use std::process;
 use structopt::StructOpt;
@@ -55,10 +56,22 @@ struct Opt {
     stdin_filepath: Option<String>,
     #[structopt(subcommand)]
     cmd: Option<Command>,
+    /// Enable debug logging output
+    #[structopt(long)]
+    verbose: bool,
 }
 
 fn main() {
     let opts = Opt::from_args();
+    if opts.verbose {
+        CombinedLogger::init(vec![simplelog::TermLogger::new(
+            simplelog::LevelFilter::Info,
+            simplelog::Config::default(),
+            simplelog::TerminalMode::Mixed,
+        )])
+        .expect("problem creating logger");
+    }
+
     let mut clap_app = Opt::clap();
     let stdout = io::stdout();
     let mut handle = stdout.lock();

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -6,6 +6,7 @@ use crate::rules::{
 };
 use console::strip_ansi_codes;
 use console::style;
+use log::info;
 use serde::Serialize;
 use std::convert::TryFrom;
 use std::fs::File;
@@ -122,12 +123,14 @@ pub fn check_files(
     };
 
     if is_stdin {
+        info!("reading content from stdin");
         let sql = get_sql_from_stdin()?;
         let path = stdin_path.unwrap_or_else(|| "stdin".into());
         process_violations(&sql, &path)?;
     }
 
     for path in paths {
+        info!("checking file path: {}", path);
         let sql = get_sql_from_path(path)?;
         process_violations(&sql, path)?;
     }

--- a/src/subcommand.rs
+++ b/src/subcommand.rs
@@ -1,5 +1,6 @@
 use crate::github::{comment_on_pr, GithubError, PullRequest};
 use crate::reporter::{check_files, get_comment_body, CheckFilesError};
+use log::info;
 use serde_json::Value;
 use structopt::StructOpt;
 
@@ -107,7 +108,9 @@ pub fn check_and_comment_on_pr(
         github_pr_number,
         github_private_key_base64,
     } = cmd;
+    info!("checking files");
     let violations = check_files(&paths, is_stdin, stdin_path, exclude)?;
+    info!("generating github comment body");
     let comment_body = get_comment_body(violations);
     let pr = PullRequest {
         issue: github_pr_number,
@@ -117,6 +120,7 @@ pub fn check_and_comment_on_pr(
 
     let gh_private_key = get_github_private_key(github_private_key, github_private_key_base64)?;
 
+    info!("commenting on PR");
     Ok(comment_on_pr(
         &gh_private_key,
         github_app_id,


### PR DESCRIPTION
upload-to-github makes a few http requests to github which take a few
seconds.

Also log out the files we check.

Enabled via the new `--verbose` flag