### PR TITLE
release: v0.2.3 part 2, the cargo troubles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,15 +1420,15 @@ dependencies = [
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "squawk-github 0.1.0",
- "squawk-linter 0.1.0",
- "squawk-parser 0.1.0",
+ "squawk-github 0.2.3",
+ "squawk-linter 0.2.3",
+ "squawk-parser 0.2.3",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "squawk-github"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
  "jsonwebtoken 7.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1439,17 +1439,17 @@ dependencies = [
 
 [[package]]
 name = "squawk-linter"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
  "insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "squawk-parser 0.1.0",
+ "squawk-parser 0.2.3",
 ]
 
 [[package]]
 name = "squawk-parser"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
  "insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libpg_query-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,9 +22,9 @@ atty = "0.2"
 base64 = "0.12.2"
 simplelog = "0.8.0"
 log = "0.4.8"
-squawk-parser = { version = "0.1.0", path = "../parser" }
-squawk-linter = { version = "0.1.0", path = "../linter" }
-squawk-github = { version = "0.1.0", path = "../github" }
+squawk-parser = { path = "../parser" }
+squawk-linter = { path = "../linter" }
+squawk-github = { path = "../github" }
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squawk-github"
-version = "0.1.0"
+version = "0.2.3"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
 

--- a/linter/Cargo.toml
+++ b/linter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squawk-linter"
-version = "0.1.0"
+version = "0.2.3"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
 
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-squawk-parser = { version = "0.1.0", path = "../parser" }
+squawk-parser = { path = "../parser" }
 lazy_static = "1.4.0"
 
 [dev-dependencies]

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squawk-parser"
-version = "0.1.0"
+version = "0.2.3"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
 


### PR DESCRIPTION
Turns out every dependency crate needs to be up on crates.io for the top
level crate, the cli, to be publish.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies