### PR TITLE
update: deps crate cargo tomls

### DIFF
--- a/github/Cargo.toml
+++ b/github/Cargo.toml
@@ -3,6 +3,11 @@ name = "squawk-github"
 version = "0.2.3"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
+license = "GPL-3.0"
+description = "Postgres SQL linter Github APIs used in Squawk"
+documentation = "https://github.com/sbdchd/squawk/blob/master/README.md"
+readme = "../README.md"
+keywords = ["bot", "github", "linter"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/linter/Cargo.toml
+++ b/linter/Cargo.toml
@@ -3,6 +3,11 @@ name = "squawk-linter"
 version = "0.2.3"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
+license = "GPL-3.0"
+description = "Postgres SQL linter used in squawk"
+documentation = "https://github.com/sbdchd/squawk/blob/master/README.md"
+readme = "../README.md"
+keywords = ["postgres", "sql", "linter"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -3,6 +3,11 @@ name = "squawk-parser"
 version = "0.2.3"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
+license = "GPL-3.0"
+description = "Postgres SQL parser used in squawk"
+documentation = "https://github.com/sbdchd/squawk/blob/master/README.md"
+readme = "../README.md"
+keywords = ["postgres", "sql", "parser"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
The dep crates require metadata in their Cargo.tomls for crates.io to
accept them.

We need to publish all these crates to be able to publish the cli.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies