### PR TITLE
update(bot): comment body content

### DIFF
--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -438,6 +438,7 @@ pub fn get_comment_body(files: Vec<ViolationContent>) -> String {
 
 ### **{violations_emoji} {violation_count}** violations across **{file_count}** file(s)
 
+---
 {sql_file_content}
 
 [📚 More info on rules](https://github.com/sbdchd/squawk#rules)
@@ -497,6 +498,7 @@ SELECT 1;
 
 ### **🚒 1** violations across **1** file(s)
 
+---
 
 <h3><code>alpha.sql</code></h3>
 
@@ -564,6 +566,7 @@ ALTER TABLE "core_recipe" ADD COLUMN "foo" integer DEFAULT 10;
 
 ### **✅ 0** violations across **2** file(s)
 
+---
 
 <h3><code>alpha.sql</code></h3>
 
@@ -621,6 +624,7 @@ No violations found.
 
 ### **✅ 0** violations across **0** file(s)
 
+---
 
 
 [📚 More info on rules](https://github.com/sbdchd/squawk#rules)

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -397,21 +397,17 @@ fn get_sql_file_content(violation: ViolationContent) -> Result<String, std::io::
 
     Ok(format!(
         r#"
-<details open>
-
-<summary><code>{filename}</code></summary>
+<h3><code>{filename}</code></h3>
 
 ```sql
 {sql}
 ```
 
-### 🚒 Rule Violations ({violation_count})
+<h4>🚒 Rule Violations ({violation_count})</h4>
 
 {violation_content}
-
-</details>
-
     
+---
     "#,
         filename = violation.filename,
         sql = sql,
@@ -424,17 +420,15 @@ pub fn get_comment_body(files: Vec<ViolationContent>) -> String {
     let violations_count: usize = files.iter().map(|x| x.violations.len()).sum();
     format!(
         r#"
-# [Squawk](https://github.com/sbdchd/squawk) Report
+# Squawk Report
 
 ### **{violation_count}** violations across **{file_count}** file(s)
 
-## 🚛 Source SQL
 {sql_file_content}
----
 
 [📚 More info on rules](https://github.com/sbdchd/squawk#rules)
 
-> ⚡️ Powered by [`Squawk`](https://github.com/sbdchd/squawk)
+⚡️ Powered by [`Squawk`](https://github.com/sbdchd/squawk), a linter for PostgreSQL, focused on migrations
 "#,
         violation_count = violations_count,
         file_count = files.len(),

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -493,15 +493,12 @@ SELECT 1;
         let body = get_comment_body(violations);
 
         assert_display_snapshot!(body, @r###"
-# [Squawk](https://github.com/sbdchd/squawk) Report
+# Squawk Report
 
-### **1** violations across **1** file(s)
+### **🚒 1** violations across **1** file(s)
 
-## 🚛 Source SQL
 
-<details open>
-
-<summary><code>alpha.sql</code></summary>
+<h3><code>alpha.sql</code></h3>
 
 ```sql
 
@@ -509,7 +506,7 @@ SELECT 1;
                 
 ```
 
-### 🚒 Rule Violations (1)
+<h4>🚒 Rule Violations (1)</h4>
 
 
 ```
@@ -520,16 +517,13 @@ alpha.sql:1:0: warning: adding-not-nullable-field
   note: Adding a NOT NULL field requires exclusive locks and table rewrites.
   help: Make the field nullable.
 ```
-
-</details>
-
-    
     
 ---
+    
 
 [📚 More info on rules](https://github.com/sbdchd/squawk#rules)
 
-> ⚡️ Powered by [`Squawk`](https://github.com/sbdchd/squawk)
+⚡️ Powered by [`Squawk`](https://github.com/sbdchd/squawk), a linter for PostgreSQL, focused on migrations
 "###);
     }
 
@@ -566,15 +560,12 @@ ALTER TABLE "core_recipe" ADD COLUMN "foo" integer DEFAULT 10;
         let body = get_comment_body(violations);
 
         assert_display_snapshot!(body, @r###"
-# [Squawk](https://github.com/sbdchd/squawk) Report
+# Squawk Report
 
-### **0** violations across **2** file(s)
+### **✅ 0** violations across **2** file(s)
 
-## 🚛 Source SQL
 
-<details open>
-
-<summary><code>alpha.sql</code></summary>
+<h3><code>alpha.sql</code></h3>
 
 ```sql
 
@@ -589,18 +580,14 @@ CREATE TABLE "core_bar" (
                 
 ```
 
-### 🚒 Rule Violations (0)
+<h4>✅ Rule Violations (0)</h4>
 
-None found.
-
-</details>
-
+No violations found.
     
+---
     
 
-<details open>
-
-<summary><code>bravo.sql</code></summary>
+<h3><code>bravo.sql</code></h3>
 
 ```sql
 
@@ -608,20 +595,17 @@ ALTER TABLE "core_recipe" ADD COLUMN "foo" integer DEFAULT 10;
                 
 ```
 
-### 🚒 Rule Violations (0)
+<h4>✅ Rule Violations (0)</h4>
 
-None found.
-
-</details>
-
-    
+No violations found.
     
 ---
+    
 
 [📚 More info on rules](https://github.com/sbdchd/squawk#rules)
 
-> ⚡️ Powered by [`Squawk`](https://github.com/sbdchd/squawk)
-        "###);
+⚡️ Powered by [`Squawk`](https://github.com/sbdchd/squawk), a linter for PostgreSQL, focused on migrations
+"###);
     }
 
     /// Ideally the logic won't leave a comment when there are no migrations but
@@ -633,18 +617,16 @@ None found.
         let body = get_comment_body(violations);
 
         assert_display_snapshot!(body, @r###"
-# [Squawk](https://github.com/sbdchd/squawk) Report
+# Squawk Report
 
-### **0** violations across **0** file(s)
+### **✅ 0** violations across **0** file(s)
 
-## 🚛 Source SQL
 
----
 
 [📚 More info on rules](https://github.com/sbdchd/squawk#rules)
 
-> ⚡️ Powered by [`Squawk`](https://github.com/sbdchd/squawk)
-        "###);
+⚡️ Powered by [`Squawk`](https://github.com/sbdchd/squawk), a linter for PostgreSQL, focused on migrations
+"###);
     }
 }
 


### PR DESCRIPTION
Remove the `<detail/>`, remove some extra headers, a couple links, an indent.

Minor changes all around that should make each migration more obviously
separate.

example: https://github.com/recipeyak/recipeyak/pull/575#issuecomment-656883411