### PR TITLE
add(rule): ban-char-field, warn against using the character data type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ## Why?
 
-Prevent unexpected downtime caused by database migrations.
+Prevent unexpected downtime caused by database migrations and encourage best
+practices around Postgres schemas and SQL.
 
 Also it seemed like a nice project to spend more time with Rust.
 
@@ -206,6 +207,24 @@ it already exists.
 
 To appease this rule you can use guards like `IF NOT EXISTS` or wrap all your
 statements in a transaction.
+
+### `ban-char-field`
+
+Using `character` is likely a mistake and should almost always be replaced by `text` or `varchar`.
+
+From the postgres docs:
+
+> There is no performance difference among these three types, apart from
+> increased storage space when using the blank-padded type, and a few extra CPU
+> cycles to check the length when storing into a length-constrained column.
+> While character(n) has performance advantages in some other database systems,
+> there is no such advantage in PostgreSQL; in fact character(n) is usually the
+> slowest of the three because of its additional storage costs. In most
+> situations text or character varying should be used instead.
+
+<https://www.postgresql.org/docs/10/datatype-character.html>
+
+See the `prefer-text-field` rule for info on the advantages of `text` over `varchar`.
 
 ## Bot Setup
 

--- a/linter/src/lib.rs
+++ b/linter/src/lib.rs
@@ -6,9 +6,10 @@ extern crate lazy_static;
 
 use crate::errors::CheckSQLError;
 use crate::rules::{
-    adding_field_with_default, adding_not_nullable_field, ban_drop_database, changing_column_type,
-    constraint_missing_not_valid, disallow_unique_constraint, prefer_robust_stmts,
-    prefer_text_field, renaming_column, renaming_table, require_concurrent_index_creation,
+    adding_field_with_default, adding_not_nullable_field, ban_char_type, ban_drop_database,
+    changing_column_type, constraint_missing_not_valid, disallow_unique_constraint,
+    prefer_robust_stmts, prefer_text_field, renaming_column, renaming_table,
+    require_concurrent_index_creation,
 };
 use crate::violations::{RuleViolation, RuleViolationKind, ViolationMessage};
 use squawk_parser::ast::RootStmt;
@@ -180,6 +181,15 @@ lazy_static! {
             messages: vec![
                 ViolationMessage::Help(
                     "Consider wrapping in a transaction or adding a IF NOT EXISTS clause.".into()
+                ),
+            ]
+        },
+        SquawkRule {
+            name: RuleViolationKind::BanCharField,
+            func: ban_char_type,
+            messages: vec![
+                ViolationMessage::Help(
+                    "Use text or varchar instead.".into()
                 ),
             ]
         }

--- a/linter/src/rules/ban_char_field.rs
+++ b/linter/src/rules/ban_char_field.rs
@@ -1,0 +1,61 @@
+use crate::violations::{RuleViolation, RuleViolationKind};
+use squawk_parser::ast::{ColumnDefTypeName, QualifiedName, RootStmt, Stmt, TableElt};
+
+pub fn ban_char_type(tree: &[RootStmt]) -> Vec<RuleViolation> {
+    let mut errs = vec![];
+    for RootStmt::RawStmt(raw_stmt) in tree {
+        match &raw_stmt.stmt {
+            Stmt::CreateStmt(stmt) => {
+                for TableElt::ColumnDef(column_def) in &stmt.table_elts {
+                    let ColumnDefTypeName::TypeName(type_name) = &column_def.type_name;
+                    for QualifiedName::String(field_type_name) in &type_name.names {
+                        if field_type_name.str == "bpchar" {
+                            errs.push(RuleViolation::new(
+                                RuleViolationKind::BanCharField,
+                                raw_stmt,
+                                None,
+                            ));
+                        }
+                    }
+                }
+            }
+            _ => continue,
+        }
+    }
+    errs
+}
+
+#[cfg(test)]
+mod test_rules {
+    use crate::check_sql;
+    use insta::assert_debug_snapshot;
+    #[test]
+    fn test_creating_table_with_char_errors() {
+        let sql = r#"
+BEGIN;
+CREATE TABLE "core_bar" (
+    "id" serial NOT NULL PRIMARY KEY,
+    "alpha" char(100) NOT NULL,
+    "beta" character(100) NOT NULL,
+    "charlie" char NOT NULL,
+    "delta" character NOT NULL
+);
+COMMIT;
+        "#;
+        assert_debug_snapshot!(check_sql(sql, &[]));
+    }
+
+    #[test]
+    fn test_creating_table_with_var_char_and_text_okay() {
+        let sql = r#"
+BEGIN;
+CREATE TABLE "core_bar" (
+    "id" serial NOT NULL PRIMARY KEY,
+    "alpha" varchar(100) NOT NULL,
+    "beta" text NOT NULL
+);
+COMMIT;
+        "#;
+        assert_debug_snapshot!(check_sql(sql, &["prefer-text-field".into()]));
+    }
+}

--- a/linter/src/rules/mod.rs
+++ b/linter/src/rules/mod.rs
@@ -20,4 +20,6 @@ pub mod renaming_table;
 pub use renaming_table::*;
 pub mod require_concurrent_index_creation;
 pub use require_concurrent_index_creation::*;
+pub mod ban_char_field;
+pub use ban_char_field::*;
 mod utils;

--- a/linter/src/rules/snapshots/squawk_linter__rules__ban_char_field__test_rules__creating_table_with_char_errors.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__ban_char_field__test_rules__creating_table_with_char_errors.snap
@@ -1,0 +1,64 @@
+---
+source: linter/src/rules/ban_char_field.rs
+expression: "check_sql(sql, &[])"
+---
+Ok(
+    [
+        RuleViolation {
+            kind: BanCharField,
+            span: Span {
+                start: 7,
+                len: Some(
+                    194,
+                ),
+            },
+            messages: [
+                Help(
+                    "Use text or varchar instead.",
+                ),
+            ],
+        },
+        RuleViolation {
+            kind: BanCharField,
+            span: Span {
+                start: 7,
+                len: Some(
+                    194,
+                ),
+            },
+            messages: [
+                Help(
+                    "Use text or varchar instead.",
+                ),
+            ],
+        },
+        RuleViolation {
+            kind: BanCharField,
+            span: Span {
+                start: 7,
+                len: Some(
+                    194,
+                ),
+            },
+            messages: [
+                Help(
+                    "Use text or varchar instead.",
+                ),
+            ],
+        },
+        RuleViolation {
+            kind: BanCharField,
+            span: Span {
+                start: 7,
+                len: Some(
+                    194,
+                ),
+            },
+            messages: [
+                Help(
+                    "Use text or varchar instead.",
+                ),
+            ],
+        },
+    ],
+)

--- a/linter/src/rules/snapshots/squawk_linter__rules__ban_char_field__test_rules__creating_table_with_var_char_and_text_okay.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__ban_char_field__test_rules__creating_table_with_var_char_and_text_okay.snap
@@ -1,0 +1,7 @@
+---
+source: linter/src/rules/ban_char_field.rs
+expression: "check_sql(sql, &[\"prefer-text-field\".into()])"
+---
+Ok(
+    [],
+)

--- a/linter/src/violations.rs
+++ b/linter/src/violations.rs
@@ -32,7 +32,7 @@ impl std::fmt::Display for RuleViolationKind {
             Self::BanDropDatabase => "ban-drop-database",
             Self::PreferTextField => "prefer-text-field",
             Self::PreferRobustStmts => "prefer-robust-stmts",
-            Self::BanCharField => "ban-char-filed",
+            Self::BanCharField => "ban-char-field",
         };
         write!(f, "{}", str_value)
     }

--- a/linter/src/violations.rs
+++ b/linter/src/violations.rs
@@ -15,6 +15,7 @@ pub enum RuleViolationKind {
     BanDropDatabase,
     PreferTextField,
     PreferRobustStmts,
+    BanCharField,
 }
 
 impl std::fmt::Display for RuleViolationKind {
@@ -31,6 +32,7 @@ impl std::fmt::Display for RuleViolationKind {
             Self::BanDropDatabase => "ban-drop-database",
             Self::PreferTextField => "prefer-text-field",
             Self::PreferRobustStmts => "prefer-robust-stmts",
+            Self::BanCharField => "ban-char-filed",
         };
         write!(f, "{}", str_value)
     }
@@ -51,6 +53,7 @@ impl std::convert::TryFrom<&str> for RuleViolationKind {
             "ban-drop-database" => Ok(Self::BanDropDatabase),
             "prefer-text-field" => Ok(Self::PreferTextField),
             "prefer-robust-stmts" => Ok(Self::PreferRobustStmts),
+            "ban-char-field" => Ok(Self::BanCharField),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
`text` or `varchar` should be used instead of `character` aka `char`.

https://www.postgresql.org/docs/10/datatype-character.html

fixes: https://github.com/sbdchd/squawk/issues/50