### PR TITLE
fix(parser): function calls in SQL

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -565,6 +565,7 @@ pub struct ColumnDef {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub enum AlterTableDef {
+    FuncCall(Value),
     Constraint(Constraint),
     ColumnDef(ColumnDef),
     #[serde(rename = "A_Const")]

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -1161,6 +1161,14 @@ ALTER PUBLICATION name RENAME TO new_name
         let res = parse_sql_query(sql);
         assert_debug_snapshot!(res);
     }
+    #[test]
+    fn test_parse_func_call() {
+        let sql = r#"
+ALTER TABLE foobar ALTER COLUMN value SET DEFAULT TO_JSON(false);
+"#;
+        let res = parse_sql_query(sql);
+        assert_debug_snapshot!(res);
+    }
 
     #[test]
     fn test_create_subscription_stmt() {

--- a/parser/src/snapshots/squawk_parser__parse__tests__parse_func_call.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parse_func_call.snap
@@ -1,0 +1,112 @@
+---
+source: parser/src/parse.rs
+expression: res
+---
+Ok(
+    [
+        RawStmt(
+            RawStmt {
+                stmt: AlterTableStmt(
+                    AlterTableStmt {
+                        cmds: [
+                            AlterTableCmd(
+                                AlterTableCmd {
+                                    subtype: ColumnDefault,
+                                    name: Some(
+                                        "value",
+                                    ),
+                                    def: Some(
+                                        FuncCall(
+                                            Object({
+                                                "args": Array([
+                                                    Object({
+                                                        "TypeCast": Object({
+                                                            "arg": Object({
+                                                                "A_Const": Object({
+                                                                    "location": Number(
+                                                                        59,
+                                                                    ),
+                                                                    "val": Object({
+                                                                        "String": Object({
+                                                                            "str": String(
+                                                                                "f",
+                                                                            ),
+                                                                        }),
+                                                                    }),
+                                                                }),
+                                                            }),
+                                                            "location": Number(
+                                                                -1,
+                                                            ),
+                                                            "typeName": Object({
+                                                                "TypeName": Object({
+                                                                    "location": Number(
+                                                                        -1,
+                                                                    ),
+                                                                    "names": Array([
+                                                                        Object({
+                                                                            "String": Object({
+                                                                                "str": String(
+                                                                                    "pg_catalog",
+                                                                                ),
+                                                                            }),
+                                                                        }),
+                                                                        Object({
+                                                                            "String": Object({
+                                                                                "str": String(
+                                                                                    "bool",
+                                                                                ),
+                                                                            }),
+                                                                        }),
+                                                                    ]),
+                                                                    "typemod": Number(
+                                                                        -1,
+                                                                    ),
+                                                                }),
+                                                            }),
+                                                        }),
+                                                    }),
+                                                ]),
+                                                "funcname": Array([
+                                                    Object({
+                                                        "String": Object({
+                                                            "str": String(
+                                                                "to_json",
+                                                            ),
+                                                        }),
+                                                    }),
+                                                ]),
+                                                "location": Number(
+                                                    51,
+                                                ),
+                                            }),
+                                        ),
+                                    ),
+                                    behavior: Restrict,
+                                    missing_ok: false,
+                                },
+                            ),
+                        ],
+                        relation: RangeVar(
+                            RangeVar {
+                                catalogname: None,
+                                schemaname: None,
+                                relname: "foobar",
+                                inh: true,
+                                relpersistence: "p",
+                                alias: None,
+                                location: 13,
+                            },
+                        ),
+                        relkind: Table,
+                        missing_ok: false,
+                    },
+                ),
+                stmt_location: 0,
+                stmt_len: Some(
+                    65,
+                ),
+            },
+        ),
+    ],
+)


### PR DESCRIPTION
Handle parsing function calls in alter table definition.

Probably should have an `other` case for most of these enums but not
super easy with serde: https://github.com/serde-rs/serde/issues/912

fixes: https://github.com/sbdchd/squawk/issues/55