### PR TITLE
fix(parser): json index operator with alter table

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Install Clippy
         run: rustup component add clippy
 
+      - name: Get Clippy Version
+        run: cargo clippy --version
+
       - name: Lint
         run: ./s/lint
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "squawk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1420,15 +1420,15 @@ dependencies = [
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "squawk-github 0.4.0",
- "squawk-linter 0.4.0",
- "squawk-parser 0.4.0",
+ "squawk-github 0.4.1",
+ "squawk-linter 0.4.1",
+ "squawk-parser 0.4.1",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "squawk-github"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "jsonwebtoken 7.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1439,17 +1439,17 @@ dependencies = [
 
 [[package]]
 name = "squawk-linter"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "squawk-parser 0.4.0",
+ "squawk-parser 0.4.1",
 ]
 
 [[package]]
 name = "squawk-parser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libpg_query-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::match_wildcard_for_single_variants)]
 mod reporter;
 mod subcommand;
 use crate::reporter::{

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::match_wildcard_for_single_variants)]
+#[allow(clippy::non_ascii_literal)]
+#[allow(clippy::cast_sign_loss)]
 mod reporter;
 mod subcommand;
 use crate::reporter::{
@@ -85,7 +87,7 @@ fn main() {
                 &mut handle,
                 &opts.paths,
                 is_stdin,
-                dump_ast_kind,
+                &dump_ast_kind,
             ));
         } else {
             match check_files(&opts.paths, is_stdin, opts.stdin_filepath, opts.exclude) {

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -57,7 +57,7 @@ pub fn dump_ast_for_paths<W: io::Write>(
     f: &mut W,
     paths: &[String],
     is_stdin: bool,
-    dump_ast: DumpAstOption,
+    dump_ast: &DumpAstOption,
 ) -> Result<(), DumpAstError> {
     let mut process_dump_ast = |sql: &str| -> Result<(), DumpAstError> {
         match dump_ast {
@@ -193,8 +193,7 @@ fn fmt_gcc<W: io::Write>(
                 .iter()
                 .map(|v| {
                     match v {
-                        ViolationMessage::Note(s) => s,
-                        ViolationMessage::Help(s) => s,
+                        ViolationMessage::Note(s) | ViolationMessage::Help(s) => s,
                     }
                     .to_string()
                 })
@@ -308,7 +307,7 @@ pub fn pretty_violations(
                 // 1-indexed
                 let lineno = sql[..start].lines().count() + 1;
 
-                let content = &sql[start..start + len + 1];
+                let content = &sql[start..=start + len];
 
                 // TODO(sbdchd): could remove the leading whitespace and comments to
                 // get cleaner reports
@@ -457,7 +456,6 @@ pub fn get_comment_body(files: Vec<ViolationContent>) -> String {
     .into()
 }
 
-#[allow(clippy::non_ascii_literal)]
 #[cfg(test)]
 mod test_github_comment {
     use super::*;

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -457,6 +457,7 @@ pub fn get_comment_body(files: Vec<ViolationContent>) -> String {
     .into()
 }
 
+#[allow(clippy::non_ascii_literal)]
 #[cfg(test)]
 mod test_github_comment {
     use super::*;
@@ -741,7 +742,7 @@ SELECT 1;
         assert_debug_snapshot!(pretty_violations(violations, sql, filename));
     }
 
-    /// pretty_violations was slicing the SQL improperly, trimming off the first
+    /// `pretty_violations` was slicing the SQL improperly, trimming off the first
     /// letter.
     #[test]
     fn test_trimming_sql_newlines() {

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -78,13 +78,12 @@ fn get_github_private_key(
     github_private_key: Option<String>,
     github_private_key_base64: Option<String>,
 ) -> Result<String, SquawkError> {
-    match github_private_key {
-        Some(private_key) => Ok(private_key),
-        None => {
-            let key = github_private_key_base64.ok_or(SquawkError::GithubPrivateKeyMissing)?;
-            let bytes = base64::decode(key)?;
-            Ok(String::from_utf8(bytes)?)
-        }
+    if let Some(private_key) = github_private_key {
+        Ok(private_key)
+    } else {
+        let key = github_private_key_base64.ok_or(SquawkError::GithubPrivateKeyMissing)?;
+        let bytes = base64::decode(key)?;
+        Ok(String::from_utf8(bytes)?)
     }
 }
 

--- a/github/src/lib.rs
+++ b/github/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::single_match_else)]
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use log::info;
 use reqwest::header::{ACCEPT, AUTHORIZATION};

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -164,9 +164,9 @@ impl Default for SortByNulls {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct IndexElem {
     /// name of attribute to index, or NULL
-    name: String,
+    name: Option<String>,
     /// expression to index, or NULL
-    expr: Option<String>,
+    expr: Option<Value>,
     /// name for index column; NULL = default
     indexcolname: Option<String>,
     /// name of collation; NIL = default

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -1171,6 +1171,15 @@ ALTER TABLE foobar ALTER COLUMN value SET DEFAULT TO_JSON(false);
     }
 
     #[test]
+    fn test_json_index_operator() {
+        let sql = r#"
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_a_foo_bar" ON "a" ((foo->>'bar'));
+"#;
+        let res = parse_sql_query(sql);
+        assert_debug_snapshot!(res);
+    }
+
+    #[test]
     fn test_create_subscription_stmt() {
         let sql = r#"
 CREATE SUBSCRIPTION mysub

--- a/parser/src/snapshots/squawk_parser__parse__tests__adding_index_non_concurrently.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__adding_index_non_concurrently.snap
@@ -13,7 +13,9 @@ Ok(
                         index_params: [
                             IndexElem(
                                 IndexElem {
-                                    name: "field_name",
+                                    name: Some(
+                                        "field_name",
+                                    ),
                                     expr: None,
                                     indexcolname: None,
                                     collation: None,
@@ -60,7 +62,9 @@ Ok(
                         index_params: [
                             IndexElem(
                                 IndexElem {
-                                    name: "field_name",
+                                    name: Some(
+                                        "field_name",
+                                    ),
                                     expr: None,
                                     indexcolname: None,
                                     collation: None,

--- a/parser/src/snapshots/squawk_parser__parse__tests__json_index_operator.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__json_index_operator.snap
@@ -1,0 +1,105 @@
+---
+source: parser/src/parse.rs
+expression: res
+---
+Ok(
+    [
+        RawStmt(
+            RawStmt {
+                stmt: IndexStmt(
+                    IndexStmt {
+                        access_method: "btree",
+                        idxname: "idx_a_foo_bar",
+                        index_params: [
+                            IndexElem(
+                                IndexElem {
+                                    name: None,
+                                    expr: Some(
+                                        Object({
+                                            "A_Expr": Object({
+                                                "kind": Number(
+                                                    0,
+                                                ),
+                                                "lexpr": Object({
+                                                    "ColumnRef": Object({
+                                                        "fields": Array([
+                                                            Object({
+                                                                "String": Object({
+                                                                    "str": String(
+                                                                        "foo",
+                                                                    ),
+                                                                }),
+                                                            }),
+                                                        ]),
+                                                        "location": Number(
+                                                            66,
+                                                        ),
+                                                    }),
+                                                }),
+                                                "location": Number(
+                                                    69,
+                                                ),
+                                                "name": Array([
+                                                    Object({
+                                                        "String": Object({
+                                                            "str": String(
+                                                                "->>",
+                                                            ),
+                                                        }),
+                                                    }),
+                                                ]),
+                                                "rexpr": Object({
+                                                    "A_Const": Object({
+                                                        "location": Number(
+                                                            72,
+                                                        ),
+                                                        "val": Object({
+                                                            "String": Object({
+                                                                "str": String(
+                                                                    "bar",
+                                                                ),
+                                                            }),
+                                                        }),
+                                                    }),
+                                                }),
+                                            }),
+                                        }),
+                                    ),
+                                    indexcolname: None,
+                                    collation: None,
+                                    opclass: [],
+                                    ordering: Default,
+                                    nulls_ordering: Default,
+                                },
+                            ),
+                        ],
+                        relation: RangeVar(
+                            RangeVar {
+                                catalogname: None,
+                                schemaname: None,
+                                relname: "a",
+                                inh: true,
+                                relpersistence: "p",
+                                alias: None,
+                                location: 60,
+                            },
+                        ),
+                        concurrent: true,
+                        unique: false,
+                        primary: false,
+                        isconstraint: false,
+                        deferrable: false,
+                        initdeferred: false,
+                        transformed: false,
+                        if_not_exists: true,
+                        table_space: None,
+                    },
+                ),
+                stmt_location: 0,
+                stmt_len: Some(
+                    79,
+                ),
+            },
+        ),
+    ],
+)

--- a/parser/src/snapshots/squawk_parser__parse__tests__migration.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__migration.snap
@@ -26,7 +26,9 @@ Ok(
                         index_params: [
                             IndexElem(
                                 IndexElem {
-                                    name: "field_name",
+                                    name: Some(
+                                        "field_name",
+                                    ),
                                     expr: None,
                                     indexcolname: None,
                                     collation: None,
@@ -73,7 +75,9 @@ Ok(
                         index_params: [
                             IndexElem(
                                 IndexElem {
-                                    name: "field_name",
+                                    name: Some(
+                                        "field_name",
+                                    ),
                                     expr: None,
                                     indexcolname: None,
                                     collation: None,

--- a/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_create_index.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_create_index.snap
@@ -13,7 +13,9 @@ Ok(
                         index_params: [
                             IndexElem(
                                 IndexElem {
-                                    name: "table_field",
+                                    name: Some(
+                                        "table_field",
+                                    ),
                                     expr: None,
                                     indexcolname: None,
                                     collation: None,

--- a/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_create_index_concurrently.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_create_index_concurrently.snap
@@ -13,7 +13,9 @@ Ok(
                         index_params: [
                             IndexElem(
                                 IndexElem {
-                                    name: "table_field",
+                                    name: Some(
+                                        "table_field",
+                                    ),
                                     expr: None,
                                     indexcolname: None,
                                     collation: None,

--- a/parser/src/snapshots/squawk_parser__parse__tests__parsing_create_table.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parsing_create_table.snap
@@ -502,7 +502,9 @@ Ok(
                         index_params: [
                             IndexElem(
                                 IndexElem {
-                                    name: "age",
+                                    name: Some(
+                                        "age",
+                                    ),
                                     expr: None,
                                     indexcolname: None,
                                     collation: None,

--- a/s/lint
+++ b/s/lint
@@ -2,4 +2,4 @@
 set -eu
 
 cargo fmt -- --check
-cargo clippy --all-targets --all-features -- -D clippy::nursery  
+cargo clippy --all-targets --all-features -- -D clippy::pedantic


### PR DESCRIPTION
Turns out `name` is an Option and that `expr` can be a more complicated
object rather than just a string.

Previously we didn't have any tests that exercised the `expr` property.

I think the issues with clippy are related to: https://github.com/rust-lang/rust-clippy/issues/2604

fixes: https://github.com/sbdchd/squawk/issues/59