### PR TITLE
fix(ci): pin toolchain version so we don't get surprising updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Install Rust Fmt
         run: rustup component add rustfmt
 
+      - name: Install Clippy
+        run: rustup component add clippy
+
       - name: Lint
         run: ./s/lint
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,9 @@ jobs:
           default: true
           override: true
 
+      - name: Install Rust Fmt
+        run: rustup component add rustfmt
+
       - name: Lint
         run: ./s/lint
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.46.0
           default: true
           override: true
 
@@ -42,7 +42,7 @@ jobs:
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.46.0
           target: x86_64-apple-darwin
           default: true
           override: true
@@ -69,7 +69,7 @@ jobs:
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.46.0
           default: true
           override: true
 
@@ -86,7 +86,7 @@ jobs:
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.46.0
           default: true
           override: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "squawk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1420,15 +1420,15 @@ dependencies = [
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "squawk-github 0.4.0",
- "squawk-linter 0.4.0",
- "squawk-parser 0.4.0",
+ "squawk-github 0.4.1",
+ "squawk-linter 0.4.1",
+ "squawk-parser 0.4.1",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "squawk-github"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "jsonwebtoken 7.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1439,17 +1439,17 @@ dependencies = [
 
 [[package]]
 name = "squawk-linter"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "squawk-parser 0.4.0",
+ "squawk-parser 0.4.1",
 ]
 
 [[package]]
 name = "squawk-parser"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "insta 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libpg_query-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -372,7 +372,7 @@ pub fn explain_rule<W: io::Write>(writer: &mut W, name: &str) -> Result<(), std:
     Ok(())
 }
 
-fn get_violations_emoji(count: usize) -> &'static str {
+const fn get_violations_emoji(count: usize) -> &'static str {
     if count > 0 {
         "🚒"
     } else {


### PR DESCRIPTION
Previous we used the generic "stable" toolchain so if a new version of
stable was released w/ updates the clippy our CI could fail on the next
run.

Now we pin to a specific version so we don't get any surprises.