### PR TITLE
fix(rules): prefer text field to also check column additions

### DIFF
--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_text_field__test_rules__adding_column_non_text.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_text_field__test_rules__adding_column_non_text.snap
@@ -1,0 +1,23 @@
+---
+source: linter/src/rules/prefer_text_field.rs
+expression: data
+---
+[
+    RuleViolation {
+        kind: PreferTextField,
+        span: Span {
+            start: 7,
+            len: Some(
+                66,
+            ),
+        },
+        messages: [
+            Note(
+                "Changing the size of a varchar field requires an ACCESS EXCLUSIVE lock.",
+            ),
+            Help(
+                "Use a text field with a check constraint.",
+            ),
+        ],
+    },
+]


### PR DESCRIPTION
Previously we were only checking table creation. Now we check both table
creation and column creation.

Moved a tiny bit of logic into a helper to save a couple lines of code.
Kind of shows the need for a proper visitor setup.