### PR TITLE
fix(parser): handle case where table etl is a constraint

### DIFF
--- a/linter/src/rules/ban_char_field.rs
+++ b/linter/src/rules/ban_char_field.rs
@@ -7,15 +7,17 @@ pub fn ban_char_type(tree: &[RootStmt]) -> Vec<RuleViolation> {
     for RootStmt::RawStmt(raw_stmt) in tree {
         match &raw_stmt.stmt {
             Stmt::CreateStmt(stmt) => {
-                for TableElt::ColumnDef(column_def) in &stmt.table_elts {
-                    let ColumnDefTypeName::TypeName(type_name) = &column_def.type_name;
-                    for QualifiedName::String(field_type_name) in &type_name.names {
-                        if field_type_name.str == "bpchar" {
-                            errs.push(RuleViolation::new(
-                                RuleViolationKind::BanCharField,
-                                raw_stmt,
-                                None,
-                            ));
+                for column_def in &stmt.table_elts {
+                    if let TableElt::ColumnDef(column_def) = column_def {
+                        let ColumnDefTypeName::TypeName(type_name) = &column_def.type_name;
+                        for QualifiedName::String(field_type_name) in &type_name.names {
+                            if field_type_name.str == "bpchar" {
+                                errs.push(RuleViolation::new(
+                                    RuleViolationKind::BanCharField,
+                                    raw_stmt,
+                                    None,
+                                ));
+                            }
                         }
                     }
                 }

--- a/linter/src/rules/prefer_text_field.rs
+++ b/linter/src/rules/prefer_text_field.rs
@@ -13,8 +13,10 @@ pub fn prefer_text_field(tree: &[RootStmt]) -> Vec<RuleViolation> {
     for RootStmt::RawStmt(raw_stmt) in tree {
         match &raw_stmt.stmt {
             Stmt::CreateStmt(stmt) => {
-                for TableElt::ColumnDef(column_def) in &stmt.table_elts {
-                    check_column_def(&mut errs, raw_stmt, column_def)
+                for column_def in &stmt.table_elts {
+                    if let TableElt::ColumnDef(column_def) = column_def {
+                        check_column_def(&mut errs, raw_stmt, column_def)
+                    }
                 }
             }
             Stmt::AlterTableStmt(stmt) => {

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -679,6 +679,7 @@ pub struct RenameStmt {
 #[derive(Debug, Deserialize, Serialize)]
 pub enum TableElt {
     ColumnDef(ColumnDef),
+    Constraint(Constraint),
 }
 
 /// What to do at commit time for temporary relations

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -1208,4 +1208,18 @@ DROP SUBSCRIPTION mysub;
         let res = parse_sql_query(sql);
         assert_debug_snapshot!(res);
     }
+
+    #[test]
+    fn test_parse_create_table_regression() {
+        let sql = r#"
+CREATE TABLE example (
+    a integer,
+    b integer,
+    c integer,
+    PRIMARY KEY (a, c)
+);
+"#;
+        let res = parse_sql_query(sql);
+        assert_debug_snapshot!(res);
+    }
 }

--- a/parser/src/snapshots/squawk_parser__parse__tests__parse_create_table_regression.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parse_create_table_regression.snap
@@ -1,0 +1,169 @@
+---
+source: parser/src/parse.rs
+expression: res
+---
+Ok(
+    [
+        RawStmt(
+            RawStmt {
+                stmt: CreateStmt(
+                    CreateStmt {
+                        relation: RangeVar(
+                            RangeVar {
+                                catalogname: None,
+                                schemaname: None,
+                                relname: "example",
+                                inh: true,
+                                relpersistence: "p",
+                                alias: None,
+                                location: 14,
+                            },
+                        ),
+                        table_elts: [
+                            ColumnDef(
+                                ColumnDef {
+                                    colname: Some(
+                                        "a",
+                                    ),
+                                    type_name: TypeName(
+                                        TypeName {
+                                            names: [
+                                                String(
+                                                    PGString {
+                                                        str: "pg_catalog",
+                                                    },
+                                                ),
+                                                String(
+                                                    PGString {
+                                                        str: "int4",
+                                                    },
+                                                ),
+                                            ],
+                                            type_oid: None,
+                                            setof: false,
+                                            pct_type: false,
+                                            typmods: [],
+                                            typemod: -1,
+                                            array_bounds: [],
+                                            location: 30,
+                                        },
+                                    ),
+                                    constraints: [],
+                                    is_local: true,
+                                    location: 28,
+                                },
+                            ),
+                            ColumnDef(
+                                ColumnDef {
+                                    colname: Some(
+                                        "b",
+                                    ),
+                                    type_name: TypeName(
+                                        TypeName {
+                                            names: [
+                                                String(
+                                                    PGString {
+                                                        str: "pg_catalog",
+                                                    },
+                                                ),
+                                                String(
+                                                    PGString {
+                                                        str: "int4",
+                                                    },
+                                                ),
+                                            ],
+                                            type_oid: None,
+                                            setof: false,
+                                            pct_type: false,
+                                            typmods: [],
+                                            typemod: -1,
+                                            array_bounds: [],
+                                            location: 45,
+                                        },
+                                    ),
+                                    constraints: [],
+                                    is_local: true,
+                                    location: 43,
+                                },
+                            ),
+                            ColumnDef(
+                                ColumnDef {
+                                    colname: Some(
+                                        "c",
+                                    ),
+                                    type_name: TypeName(
+                                        TypeName {
+                                            names: [
+                                                String(
+                                                    PGString {
+                                                        str: "pg_catalog",
+                                                    },
+                                                ),
+                                                String(
+                                                    PGString {
+                                                        str: "int4",
+                                                    },
+                                                ),
+                                            ],
+                                            type_oid: None,
+                                            setof: false,
+                                            pct_type: false,
+                                            typmods: [],
+                                            typemod: -1,
+                                            array_bounds: [],
+                                            location: 60,
+                                        },
+                                    ),
+                                    constraints: [],
+                                    is_local: true,
+                                    location: 58,
+                                },
+                            ),
+                            Constraint(
+                                Constraint {
+                                    contype: Primary,
+                                    location: 73,
+                                    raw_expr: None,
+                                    keys: Some(
+                                        Array([
+                                            Object({
+                                                "String": Object({
+                                                    "str": String(
+                                                        "a",
+                                                    ),
+                                                }),
+                                            }),
+                                            Object({
+                                                "String": Object({
+                                                    "str": String(
+                                                        "c",
+                                                    ),
+                                                }),
+                                            }),
+                                        ]),
+                                    ),
+                                    indexname: None,
+                                    skip_validation: false,
+                                    initially_valid: false,
+                                },
+                            ),
+                        ],
+                        inh_relations: [],
+                        partbound: None,
+                        partspec: None,
+                        of_typename: None,
+                        constraints: [],
+                        options: [],
+                        oncommit: Noop,
+                        tablespacename: None,
+                        if_not_exists: false,
+                    },
+                ),
+                stmt_location: 0,
+                stmt_len: Some(
+                    93,
+                ),
+            },
+        ),
+    ],
+)


### PR DESCRIPTION
Previously squawk assumed that a tableEtl could only be a column type.

Seems the doc comment in the PG source is incorrect:

https://github.com/postgres/postgres/blob/20d3fe9009ddbbbb3da3a2da298f922054b43f8c/src/include/nodes/parsenodes.h#L2075

rel: https://github.com/sbdchd/squawk/issues/70