### PR TITLE
fix(parser): handle `RangeVar` with missing `inh` field.

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -196,6 +196,7 @@ pub struct RangeVar {
     /// the relation/sequence name
     pub relname: String,
     /// expand rel by inheritance? recursively act on children?
+    #[serde(default)]
     pub inh: bool,
     /// see RELPERSISTENCE_* in pg_class.h
     pub relpersistence: String,

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -1220,6 +1220,22 @@ DROP SUBSCRIPTION mysub;
     }
 
     #[test]
+    fn parse_inh() {
+        let sql = r#"
+ALTER TABLE ONLY public.tasks
+    DROP CONSTRAINT tasks_fk,
+    ADD CONSTRAINT tasks_fk
+        FOREIGN KEY (job_id) REFERENCES public.jobs(external_id)
+            ON DELETE CASCADE NOT VALID;
+
+ALTER TABLE public.tasks VALIDATE CONSTRAINT tasks_fk;
+"#;
+        let res = parse_sql_query(sql);
+        assert!(res.is_ok());
+        assert_debug_snapshot!(res);
+    }
+
+    #[test]
     fn test_parse_create_table_regression() {
         let sql = r#"
 CREATE TABLE example (

--- a/parser/src/snapshots/squawk_parser__parse__tests__parse_inh.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parse_inh.snap
@@ -1,0 +1,109 @@
+---
+source: parser/src/parse.rs
+expression: res
+---
+Ok(
+    [
+        RawStmt(
+            RawStmt {
+                stmt: AlterTableStmt(
+                    AlterTableStmt {
+                        cmds: [
+                            AlterTableCmd(
+                                AlterTableCmd {
+                                    subtype: DropConstraint,
+                                    name: Some(
+                                        "tasks_fk",
+                                    ),
+                                    def: None,
+                                    behavior: Restrict,
+                                    missing_ok: false,
+                                },
+                            ),
+                            AlterTableCmd(
+                                AlterTableCmd {
+                                    subtype: AddConstraint,
+                                    name: None,
+                                    def: Some(
+                                        Constraint(
+                                            Constraint {
+                                                contype: Foreign,
+                                                location: 69,
+                                                raw_expr: None,
+                                                keys: None,
+                                                indexname: None,
+                                                skip_validation: true,
+                                                initially_valid: false,
+                                            },
+                                        ),
+                                    ),
+                                    behavior: Restrict,
+                                    missing_ok: false,
+                                },
+                            ),
+                        ],
+                        relation: RangeVar(
+                            RangeVar {
+                                catalogname: None,
+                                schemaname: Some(
+                                    "public",
+                                ),
+                                relname: "tasks",
+                                inh: false,
+                                relpersistence: "p",
+                                alias: None,
+                                location: 18,
+                            },
+                        ),
+                        relkind: Table,
+                        missing_ok: false,
+                    },
+                ),
+                stmt_location: 0,
+                stmt_len: Some(
+                    193,
+                ),
+            },
+        ),
+        RawStmt(
+            RawStmt {
+                stmt: AlterTableStmt(
+                    AlterTableStmt {
+                        cmds: [
+                            AlterTableCmd(
+                                AlterTableCmd {
+                                    subtype: ValidateConstraint,
+                                    name: Some(
+                                        "tasks_fk",
+                                    ),
+                                    def: None,
+                                    behavior: Restrict,
+                                    missing_ok: false,
+                                },
+                            ),
+                        ],
+                        relation: RangeVar(
+                            RangeVar {
+                                catalogname: None,
+                                schemaname: Some(
+                                    "public",
+                                ),
+                                relname: "tasks",
+                                inh: true,
+                                relpersistence: "p",
+                                alias: None,
+                                location: 208,
+                            },
+                        ),
+                        relkind: Table,
+                        missing_ok: false,
+                    },
+                ),
+                stmt_location: 194,
+                stmt_len: Some(
+                    55,
+                ),
+            },
+        ),
+    ],
+)


### PR DESCRIPTION
`inh` isn't always present on the `RangeVar` so we default it to `false`.

rel: https://github.com/sbdchd/squawk/issues/79