### PR TITLE
add npm badge and remove crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# squawk [![cargo-badge](https://img.shields.io/crates/v/squawk.svg)](https://crates.io/crates/squawk) ![Rust CI](https://github.com/sbdchd/squawk/workflows/Rust%20CI/badge.svg)
+# squawk [![cargo-badge](https://img.shields.io/crates/v/squawk.svg)](https://crates.io/crates/squawk) ![npm](https://img.shields.io/npm/v/squawk-cli) ![Rust CI](https://github.com/sbdchd/squawk/workflows/Rust%20CI/badge.svg)
 
 > linter for Postgres migrations
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# squawk [![cargo-badge](https://img.shields.io/crates/v/squawk.svg)](https://crates.io/crates/squawk) ![npm](https://img.shields.io/npm/v/squawk-cli) ![Rust CI](https://github.com/sbdchd/squawk/workflows/Rust%20CI/badge.svg)
+# squawk ![npm](https://img.shields.io/npm/v/squawk-cli) ![Rust CI](https://github.com/sbdchd/squawk/workflows/Rust%20CI/badge.svg)
 
 > linter for Postgres migrations
 
@@ -17,8 +17,6 @@ only supports Linux and macOS
 
 ```shell
 npm install -g squawk-cli
-
-cargo install squawk
 
 # or install binaries directly via the releases page
 https://github.com/sbdchd/squawk/releases
@@ -396,7 +394,6 @@ cargo run
    `Cargo.toml` as well as the CLI `Cargo.toml`
 2. create a new release on github - CI will attach the binaries automatically
 3. bump version in `package.json` and follow the `npm` steps
-4. publish each crate to cargo in a DAG fashion
 
 ## how it works
 


### PR DESCRIPTION
added npm badge because that is where the latest versions of squawk are available. The crates.io version is no longer updated, so I've removed the badge and installation instructions.