### PR TITLE
add: better error reporting

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -108,8 +108,8 @@ fn main() {
                         }
                     }
                 }
-                e => {
-                    eprintln!("{:#?}", e);
+                Err(e) => {
+                    eprintln!("{}", e);
                     process::exit(1)
                 }
             }

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -93,6 +93,16 @@ pub enum CheckFilesError {
     IoError(std::io::Error),
 }
 
+impl std::fmt::Display for CheckFilesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::CheckSQL(ref err) => {
+                write!(f, "{}", format!("Problem linting SQL files: {}", err))
+            }
+            Self::IoError(ref err) => err.fmt(f),
+        }
+    }
+}
 impl std::convert::From<std::io::Error> for CheckFilesError {
     fn from(e: std::io::Error) -> Self {
         Self::IoError(e)

--- a/linter/src/errors.rs
+++ b/linter/src/errors.rs
@@ -8,7 +8,7 @@ pub enum CheckSQLError {
 impl std::fmt::Display for CheckSQLError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            Self::ParsingSQL(ref err) => write!(f, "{}", format!("Failed to parse query: {}", err)),
+            Self::ParsingSQL(ref err) => err.fmt(f),
         }
     }
 }

--- a/linter/src/errors.rs
+++ b/linter/src/errors.rs
@@ -5,6 +5,14 @@ pub enum CheckSQLError {
     ParsingSQL(PGQueryError),
 }
 
+impl std::fmt::Display for CheckSQLError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::ParsingSQL(ref err) => write!(f, "{}", format!("Failed to parse query: {}", err)),
+        }
+    }
+}
+
 impl std::convert::From<PGQueryError> for CheckSQLError {
     fn from(err: PGQueryError) -> Self {
         Self::ParsingSQL(err)

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -1,21 +1,24 @@
-use serde::Serialize;
-
-#[derive(Debug, PartialEq, Serialize)]
-pub struct ParseError {
-    pub message: Option<String>,
-    pub funcname: Option<String>,
-    pub filename: Option<String>,
-    pub lineno: i32,
-    pub cursorpos: i32,
-    pub context: Option<String>,
-}
-
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, PartialEq)]
 pub enum PGQueryError {
     ParsingCString,
     JsonParse(String),
     QueryToCString,
-    PGParseError(ParseError),
+    PGParseError,
+}
+
+impl std::fmt::Display for PGQueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::ParsingCString => write!(f, "Could not convert API response from CString"),
+            Self::JsonParse(ref err) => write!(
+                f,
+                "{}",
+                format!("Squawk schema failed to parse Postgres response: {}", err)
+            ),
+            Self::QueryToCString => write!(f, "Could not encode query into CString"),
+            Self::PGParseError => write!(f, "Postgres failed to parse query"),
+        }
+    }
 }
 
 impl std::convert::From<std::ffi::NulError> for PGQueryError {

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -36,12 +36,6 @@ impl std::convert::From<serde_json::error::Error> for PGQueryError {
     }
 }
 
-impl std::convert::From<std::ffi::IntoStringError> for PGQueryError {
-    fn from(_: std::ffi::IntoStringError) -> Self {
-        Self::ParsingCString
-    }
-}
-
 impl std::convert::From<std::str::Utf8Error> for PGQueryError {
     fn from(_: std::str::Utf8Error) -> Self {
         Self::ParsingCString

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -9,7 +9,10 @@ pub enum PGQueryError {
 impl std::fmt::Display for PGQueryError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            Self::ParsingCString => write!(f, "Could not convert API response from CString"),
+            Self::ParsingCString => write!(
+                f,
+                "Could not convert Postgres response from CString to String"
+            ),
             Self::JsonParse(ref err) => write!(
                 f,
                 "{}",

--- a/parser/src/snapshots/squawk_parser__parse__tests__create_procedure_stmt.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__create_procedure_stmt.snap
@@ -3,20 +3,5 @@ source: parser/src/parse.rs
 expression: res
 ---
 Err(
-    PGParseError(
-        ParseError {
-            message: Some(
-                "syntax error at or near \"PROCEDURE\"",
-            ),
-            funcname: Some(
-                "scanner_yyerror",
-            ),
-            filename: Some(
-                "scan.l",
-            ),
-            lineno: 1121,
-            cursorpos: 9,
-            context: None,
-        },
-    ),
+    PGParseError,
 )

--- a/parser/src/snapshots/squawk_parser__parse__tests__error_paths.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__error_paths.snap
@@ -3,20 +3,5 @@ source: parser/src/parse.rs
 expression: res
 ---
 Err(
-    PGParseError(
-        ParseError {
-            message: Some(
-                "syntax error at or near \"lsakdjf\"",
-            ),
-            funcname: Some(
-                "scanner_yyerror",
-            ),
-            filename: Some(
-                "scan.l",
-            ),
-            lineno: 1121,
-            cursorpos: 1,
-            context: None,
-        },
-    ),
+    PGParseError,
 )


### PR DESCRIPTION
We use `Debug` formatting for errors which looks like junk and isn't that useful to end users. Implementing `Display` allows us to present nicer errors.

I deleted the `ParseError` struct because it didn't seem helpful.

# examples

## poorly formed sql

`echo hello world | squawk`

Before

```
Err(
    CheckSQL(
        ParsingSQL(
            PGParseError(
                ParseError {
                    message: Some(
                        "syntax error at or near \"hello\"",
                    ),
                    funcname: Some(
                        "scanner_yyerror",
                    ),
                    filename: Some(
                        "scan.l",
                    ),
                    lineno: 1121,
                    cursorpos: 1,
                    context: None,
                },
            ),
        ),
    ),
)
```

After

```
Problem linting SQL files: Postgres failed to parse query
```

## invalid Squawk schema

```
squawk << EOF
ALTER TABLE "table_name" ALTER COLUMN "column_name" SET DEFAULT false;
EOF
```

Before
```
Err(
    CheckSQL(
        ParsingSQL(
            JsonParse(
                "unknown variant `TypeCast`, expected one of `FuncCall`, `Constraint`, `ColumnDef`, `A_Const`, `ReplicaIdentityStmt` at line 1 column 230",
            ),
        ),
    ),
)
```

After
```
Problem linting SQL files: Squawk schema failed to parse Postgres response: unknown variant `TypeCast`, expected one of `FuncCall`, `Constraint`, `ColumnDef`, `A_Const`, `ReplicaIdentityStmt` at line 1 column 230
```