### PR TITLE
add: better error reporting part 2

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,11 +14,11 @@ use std::io;
 use std::process;
 use structopt::StructOpt;
 
-fn handle_exit_err<E: std::fmt::Debug>(res: Result<(), E>) -> ! {
+fn handle_exit_err<E: std::fmt::Display>(res: Result<(), E>) -> ! {
     match res {
         Ok(_) => process::exit(0),
         Err(err) => {
-            eprintln!("{:#?}", err);
+            eprintln!("{}", err);
             process::exit(1)
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,11 +14,11 @@ use std::io;
 use std::process;
 use structopt::StructOpt;
 
-fn handle_exit_err<E: std::fmt::Display>(res: Result<(), E>) -> ! {
+fn exit<E: std::fmt::Display, T>(res: Result<T, E>, msg: &str) -> ! {
     match res {
         Ok(_) => process::exit(0),
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{}: {}", msg, err);
             process::exit(1)
         }
     }
@@ -74,21 +74,16 @@ fn main() {
 
     let is_stdin = !atty::is(Stream::Stdin);
     if let Some(subcommand) = opts.cmd {
-        match check_and_comment_on_pr(subcommand, is_stdin, opts.stdin_filepath) {
-            Ok(_) => process::exit(0),
-            Err(err) => {
-                eprintln!("{:#?}", err);
-                process::exit(1);
-            }
-        }
+        exit(
+            check_and_comment_on_pr(subcommand, is_stdin, opts.stdin_filepath),
+            "Upload to GitHub failed",
+        );
     } else if !opts.paths.is_empty() || is_stdin {
         if let Some(dump_ast_kind) = opts.dump_ast {
-            handle_exit_err(dump_ast_for_paths(
-                &mut handle,
-                &opts.paths,
-                is_stdin,
-                &dump_ast_kind,
-            ));
+            exit(
+                dump_ast_for_paths(&mut handle, &opts.paths, is_stdin, &dump_ast_kind),
+                "Failed to dump AST",
+            );
         } else {
             match check_files(&opts.paths, is_stdin, opts.stdin_filepath, opts.exclude) {
                 Ok(file_reports) => {
@@ -103,21 +98,24 @@ fn main() {
                             process::exit(exit_code);
                         }
                         Err(e) => {
-                            eprintln!("{:#?}", e);
+                            eprintln!("Problem reporting violations: {}", e);
                             process::exit(1);
                         }
                     }
                 }
                 Err(e) => {
-                    eprintln!("{}", e);
+                    eprintln!("Problem linting SQL files: {}", e);
                     process::exit(1)
                 }
             }
         }
     } else if opts.list_rules {
-        handle_exit_err(list_rules(&mut handle));
+        exit(list_rules(&mut handle), "Could not list rules");
     } else if let Some(rule_name) = opts.explain {
-        handle_exit_err(explain_rule(&mut handle, &rule_name));
+        exit(
+            explain_rule(&mut handle, &rule_name),
+            "Could not explain rules",
+        );
     } else {
         clap_app.print_long_help().expect("problem printing help");
         println!();

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -35,6 +35,16 @@ pub enum DumpAstError {
     Json(serde_json::error::Error),
 }
 
+impl std::fmt::Display for DumpAstError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::PGQuery(ref err) => write!(f, "{}", format!("Failed to dump AST: {}", err)),
+            Self::Io(ref err) => write!(f, "{}", format!("Failed to dump AST: {}", err)),
+            Self::Json(ref err) => write!(f, "{}", format!("Failed to dump AST: {}", err)),
+        }
+    }
+}
+
 impl std::convert::From<PGQueryError> for DumpAstError {
     fn from(e: PGQueryError) -> Self {
         Self::PGQuery(e)

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -38,9 +38,9 @@ pub enum DumpAstError {
 impl std::fmt::Display for DumpAstError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            Self::PGQuery(ref err) => write!(f, "{}", format!("Failed to dump AST: {}", err)),
-            Self::Io(ref err) => write!(f, "{}", format!("Failed to dump AST: {}", err)),
-            Self::Json(ref err) => write!(f, "{}", format!("Failed to dump AST: {}", err)),
+            Self::PGQuery(ref err) => err.fmt(f),
+            Self::Io(ref err) => err.fmt(f),
+            Self::Json(ref err) => err.fmt(f),
         }
     }
 }
@@ -106,9 +106,7 @@ pub enum CheckFilesError {
 impl std::fmt::Display for CheckFilesError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
-            Self::CheckSQL(ref err) => {
-                write!(f, "{}", format!("Problem linting SQL files: {}", err))
-            }
+            Self::CheckSQL(ref err) => err.fmt(f),
             Self::IoError(ref err) => err.fmt(f),
         }
     }

--- a/github/src/lib.rs
+++ b/github/src/lib.rs
@@ -99,6 +99,19 @@ pub enum GithubError {
     HttpError(reqwest::Error),
 }
 
+impl std::fmt::Display for GithubError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::JsonWebTokenCreation(ref err) => {
+                write!(f, "{}", format!("Could not create JWT: {}", err))
+            }
+            Self::HttpError(ref err) => {
+                write!(f, "{}", format!("Problem calling GitHub API: {}", err))
+            }
+        }
+    }
+}
+
 impl std::convert::From<reqwest::Error> for GithubError {
     fn from(e: reqwest::Error) -> Self {
         Self::HttpError(e)

--- a/parser/src/error.rs
+++ b/parser/src/error.rs
@@ -16,7 +16,7 @@ impl std::fmt::Display for PGQueryError {
             Self::JsonParse(ref err) => write!(
                 f,
                 "{}",
-                format!("Squawk schema failed to parse Postgres response: {}", err)
+                format!("Squawk schema failed to parse Postgres response. This indicates a bug with Squawk. Please report this error to https://github.com/sbdchd/squawk. Schema error: {}", err)
             ),
             Self::QueryToCString => write!(f, "Could not encode query into CString"),
             Self::PGParseError => write!(f, "Postgres failed to parse query"),


### PR DESCRIPTION
# examples

Missing private key
```
# before
GithubPrivateKeyMissing

# after
Upload to GitHub failed: Missing GitHub private key
```

bad private key
```
# before
GithubError(
    JsonWebTokenCreation(
        Error(
            InvalidKeyFormat,
        ),
    ),
)

# after
Upload to GitHub failed: Could not create JWT: InvalidKeyFormat
```

API call error
```
# before
GithubError(
    HttpError(
        Error(
            Status(
                404,
            ),
            "https://api.github.com/app",
        ),
    ),
)

# after
Upload to GitHub failed: Problem calling GitHub API: https://api.github.com/app: Client Error: 404 Not Found
```

Schema error

```
# before
Problem linting SQL files: Squawk schema failed to parse Postgres response: unknown variant `FuncCall`, expected one of `Constraint`, `ColumnDef`, `A_Const`, `ReplicaIdentityStmt` at line 1 column 220

# after
Problem linting SQL files: Squawk schema failed to parse Postgres response. This indicates a bug with Squawk. Please report this error to https://github.com/sbdchd/squawk. Schema error: unknown variant `FuncCall`, expected one of `Constraint`, `ColumnDef`, `A_Const`, `ReplicaIdentityStmt` at line 1 column 220
```