### PR TITLE
add detail to robust stmts warning

### DIFF
--- a/linter/src/lib.rs
+++ b/linter/src/lib.rs
@@ -195,7 +195,7 @@ lazy_static! {
             func: prefer_robust_stmts,
             messages: vec![
                 ViolationMessage::Help(
-                    "Consider wrapping in a transaction or adding a IF NOT EXISTS clause.".into()
+                    "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.".into()
                 ),
             ]
         },

--- a/linter/src/lib.rs
+++ b/linter/src/lib.rs
@@ -195,7 +195,7 @@ lazy_static! {
             func: prefer_robust_stmts,
             messages: vec![
                 ViolationMessage::Help(
-                    "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.".into()
+                    "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if the statment supports it.".into()
                 ),
             ]
         },

--- a/linter/src/rules/prefer_robust_stmts.rs
+++ b/linter/src/rules/prefer_robust_stmts.rs
@@ -129,7 +129,7 @@ ALTER TABLE "core_foo" ADD COLUMN "answer_id" integer NULL;
                     },
                     messages: [
                         Help(
-                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause.",
+                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.",
                         ),
                     ],
                 },
@@ -153,7 +153,7 @@ CREATE INDEX CONCURRENTLY "core_foo_idx" ON "core_foo" ("answer_id");
                     },
                     messages: [
                         Help(
-                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause.",
+                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.",
                         ),
                     ],
                 },
@@ -177,7 +177,7 @@ CREATE TABLE "core_bar" ( "id" serial NOT NULL PRIMARY KEY, "bravo" text NOT NUL
                     },
                     messages: [
                         Help(
-                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause.",
+                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.",
                         ),
                     ],
                 },
@@ -201,7 +201,7 @@ ALTER TABLE "core_foo" DROP CONSTRAINT "core_foo_idx";
                     },
                     messages: [
                         Help(
-                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause.",
+                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.",
                         ),
                     ],
                 },

--- a/linter/src/rules/prefer_robust_stmts.rs
+++ b/linter/src/rules/prefer_robust_stmts.rs
@@ -129,7 +129,7 @@ ALTER TABLE "core_foo" ADD COLUMN "answer_id" integer NULL;
                     },
                     messages: [
                         Help(
-                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.",
+                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if the statment supports it.",
                         ),
                     ],
                 },
@@ -153,7 +153,7 @@ CREATE INDEX CONCURRENTLY "core_foo_idx" ON "core_foo" ("answer_id");
                     },
                     messages: [
                         Help(
-                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.",
+                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if the statment supports it.",
                         ),
                     ],
                 },
@@ -177,7 +177,7 @@ CREATE TABLE "core_bar" ( "id" serial NOT NULL PRIMARY KEY, "bravo" text NOT NUL
                     },
                     messages: [
                         Help(
-                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.",
+                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if the statment supports it.",
                         ),
                     ],
                 },
@@ -201,7 +201,7 @@ ALTER TABLE "core_foo" DROP CONSTRAINT "core_foo_idx";
                     },
                     messages: [
                         Help(
-                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if your statment supports it.",
+                            "Consider wrapping in a transaction or adding a IF NOT EXISTS clause if the statment supports it.",
                         ),
                     ],
                 },


### PR DESCRIPTION
Not all operations support IF EXISTS and IF NOT EXISTS. So I added a little caveat, "if your statement supports it".