### PR TITLE
ref(docs): use light theme that highlights keywords

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -10,7 +10,7 @@ module.exports = {
   projectName: "squawk", // Usually your repo name.
   themeConfig: {
     prism: {
-      theme: require('prism-react-renderer/themes/github'),
+      theme: require('prism-react-renderer/themes/oceanicNext'),
     },
     algolia: {
       apiKey: process.env.ALGOLIA_API_KEY,

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -9,6 +9,9 @@ module.exports = {
   organizationName: "sbdchd", // Usually your GitHub org/user name.
   projectName: "squawk", // Usually your repo name.
   themeConfig: {
+    prism: {
+      theme: require('prism-react-renderer/themes/github'),
+    },
     algolia: {
       apiKey: process.env.ALGOLIA_API_KEY,
       indexName: process.env.ALGOLIA_INDEX_NAME,


### PR DESCRIPTION
I like the dark theme but it doesn't highlight keywords making:

```sql
ALTER TABLE table_name ADD CONSTRAINT field_name_constraint UNIQUE (field_name);
```

look boring on https://squawkhq.com/docs/disallowed-unique-constraint

Instead use a different prism theme which looks better for those cases.

Before:
<img width="842" alt="Screen Shot 2021-03-24 at 6 17 19 PM" src="https://user-images.githubusercontent.com/7340772/112390996-90c5d280-8ccd-11eb-8538-7019044ff334.png">
<img width="840" alt="Screen Shot 2021-03-24 at 6 17 36 PM" src="https://user-images.githubusercontent.com/7340772/112390994-902d3c00-8ccd-11eb-9585-5c1968d86738.png">

After:

<img width="829" alt="Screen Shot 2021-03-24 at 6 23 59 PM" src="https://user-images.githubusercontent.com/7340772/112391373-311bf700-8cce-11eb-9c3e-43a0fae72fc6.png">
<img width="823" alt="Screen Shot 2021-03-24 at 6 24 18 PM" src="https://user-images.githubusercontent.com/7340772/112391374-31b48d80-8cce-11eb-8bf9-a13ba039cd8e.png">

