### PR TITLE
fix(prefer-text-field): allow varchar without a length

### DIFF
--- a/linter/src/rules/ban_drop_column.rs
+++ b/linter/src/rules/ban_drop_column.rs
@@ -18,14 +18,13 @@ pub fn ban_drop_column(tree: &[RootStmt]) -> Vec<RuleViolation> {
             },
             Stmt::AlterTableStmt(stmt) => {
                 for cmd in &stmt.cmds {
-                    if let AlterTableCmds::AlterTableCmd(cmd) = cmd {
-                        if cmd.subtype == AlterTableType::DropColumn {
-                            errs.push(RuleViolation::new(
-                                RuleViolationKind::BanDropColumn,
-                                raw_stmt.into(),
-                                None,
-                            ))
-                        }
+                    let AlterTableCmds::AlterTableCmd(cmd) = cmd;
+                    if cmd.subtype == AlterTableType::DropColumn {
+                        errs.push(RuleViolation::new(
+                            RuleViolationKind::BanDropColumn,
+                            raw_stmt.into(),
+                            None,
+                        ))
                     }
                 }
             }


### PR DESCRIPTION
We shouldn't warn about varchar without a length specified since it is
equivalent to text, which the docs outline:

> The notations varchar(n) and char(n) are aliases for
> character varying(n) and character(n), respectively. character without
> length specifier is equivalent to character(1). If character varying
> is used without length specifier, the type accepts strings of any
> size. The latter is a PostgreSQL extension.

https://www.postgresql.org/docs/current/datatype-character.html

rel: https://github.com/sbdchd/squawk/issues/137