### PR TITLE
fix(cli/upload-to-github): combine top level exclude rules arg

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -90,7 +90,12 @@ fn main() {
                 "Failed to dump AST",
             );
         } else {
-            match check_files(&opts.paths, is_stdin, opts.stdin_filepath, opts.exclude) {
+            match check_files(
+                &opts.paths,
+                is_stdin,
+                opts.stdin_filepath,
+                opts.exclude.unwrap_or_else(Vec::new),
+            ) {
                 Ok(file_reports) => {
                     let reporter = opts.reporter.unwrap_or(Reporter::Tty);
                     let total_violations = file_reports

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
                 subcommand,
                 is_stdin,
                 opts.stdin_filepath,
-                opts.exclude.unwrap_or_else(Vec::new),
+                &opts.exclude.unwrap_or_else(Vec::new),
             ),
             "Upload to GitHub failed",
         );
@@ -94,7 +94,7 @@ fn main() {
                 &opts.paths,
                 is_stdin,
                 opts.stdin_filepath,
-                opts.exclude.unwrap_or_else(Vec::new),
+                &opts.exclude.unwrap_or_else(Vec::new),
             ) {
                 Ok(file_reports) => {
                     let reporter = opts.reporter.unwrap_or(Reporter::Tty);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -75,7 +75,12 @@ fn main() {
     let is_stdin = !atty::is(Stream::Stdin);
     if let Some(subcommand) = opts.cmd {
         exit(
-            check_and_comment_on_pr(subcommand, is_stdin, opts.stdin_filepath),
+            check_and_comment_on_pr(
+                subcommand,
+                is_stdin,
+                opts.stdin_filepath,
+                opts.exclude.unwrap_or_else(Vec::new),
+            ),
             "Upload to GitHub failed",
         );
     } else if !opts.paths.is_empty() || is_stdin {

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -132,7 +132,7 @@ pub fn check_files(
     paths: &[String],
     is_stdin: bool,
     stdin_path: Option<String>,
-    excluded_rules: Vec<String>,
+    excluded_rules: &[String],
 ) -> Result<Vec<ViolationContent>, CheckFilesError> {
     let mut output_violations = vec![];
 

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -132,10 +132,8 @@ pub fn check_files(
     paths: &[String],
     is_stdin: bool,
     stdin_path: Option<String>,
-    excluded_rules: Option<Vec<String>>,
+    excluded_rules: Vec<String>,
 ) -> Result<Vec<ViolationContent>, CheckFilesError> {
-    let excluded_rules = excluded_rules.unwrap_or_else(Vec::new);
-
     let mut output_violations = vec![];
 
     let mut process_violations = |sql: &str, path: &str| -> Result<(), CheckFilesError> {

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -102,10 +102,16 @@ fn get_github_private_key(
     }
 }
 
+fn concat(a: &[String], b: &[String]) -> Vec<String> {
+    // from: https://stackoverflow.com/a/53476705/3720597
+    [a, b].concat()
+}
+
 pub fn check_and_comment_on_pr(
     cmd: Command,
     is_stdin: bool,
     stdin_path: Option<String>,
+    base_file_paths: Vec<String>,
 ) -> Result<Value, SquawkError> {
     let Command::UploadToGithub {
         paths,
@@ -119,7 +125,12 @@ pub fn check_and_comment_on_pr(
         github_private_key_base64,
     } = cmd;
     info!("checking files");
-    let file_results = check_files(&paths, is_stdin, stdin_path, exclude)?;
+    let file_results = check_files(
+        &concat(&paths, &base_file_paths),
+        is_stdin,
+        stdin_path,
+        exclude,
+    )?;
     if file_results.is_empty() {
         info!("no files checked, exiting");
         return Ok(Value::Null);

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -111,7 +111,7 @@ pub fn check_and_comment_on_pr(
     cmd: Command,
     is_stdin: bool,
     stdin_path: Option<String>,
-    root_cmd_exclude: Vec<String>,
+    root_cmd_exclude: &[String],
 ) -> Result<Value, SquawkError> {
     let Command::UploadToGithub {
         paths,
@@ -129,7 +129,7 @@ pub fn check_and_comment_on_pr(
         &paths,
         is_stdin,
         stdin_path,
-        concat(&exclude.unwrap_or_else(Vec::new), &root_cmd_exclude),
+        &concat(&exclude.unwrap_or_else(Vec::new), &root_cmd_exclude),
     )?;
     if file_results.is_empty() {
         info!("no files checked, exiting");

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -111,7 +111,7 @@ pub fn check_and_comment_on_pr(
     cmd: Command,
     is_stdin: bool,
     stdin_path: Option<String>,
-    base_file_paths: Vec<String>,
+    root_cmd_exclude: Vec<String>,
 ) -> Result<Value, SquawkError> {
     let Command::UploadToGithub {
         paths,
@@ -126,10 +126,10 @@ pub fn check_and_comment_on_pr(
     } = cmd;
     info!("checking files");
     let file_results = check_files(
-        &concat(&paths, &base_file_paths),
+        &paths,
         is_stdin,
         stdin_path,
-        exclude,
+        exclude.map(|x| concat(x.as_ref(), &root_cmd_exclude)),
     )?;
     if file_results.is_empty() {
         info!("no files checked, exiting");

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -129,7 +129,7 @@ pub fn check_and_comment_on_pr(
         &paths,
         is_stdin,
         stdin_path,
-        exclude.map(|x| concat(x.as_ref(), &root_cmd_exclude)),
+        concat(&exclude.unwrap_or_else(Vec::new), &root_cmd_exclude),
     )?;
     if file_results.is_empty() {
         info!("no files checked, exiting");


### PR DESCRIPTION
Previously, if the `exclude` flag was passed before the `upload-to-github`
subcommand, the excluded rules wouldn't actually be included.

Now we take those excluded rules into account, so

```
squawk --exclude=ban-drop-database upload-to-github
```

is the same as

```
squawk upload-to-github --exclude=ban-drop-database
```

rel: https://github.com/sbdchd/squawk/issues/141