### PR TITLE
fix(rules): allowing adding not null column with default

### DIFF
--- a/linter/src/rules/snapshots/squawk_linter__rules__adding_not_null_field__test_rules__adding_field_that_is_not_nullable.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__adding_not_null_field__test_rules__adding_field_that_is_not_nullable.snap
@@ -21,22 +21,5 @@ Ok(
                 ),
             ],
         },
-        RuleViolation {
-            kind: AddingNotNullableField,
-            span: Span {
-                start: 7,
-                len: Some(
-                    104,
-                ),
-            },
-            messages: [
-                Note(
-                    "Adding a NOT NULL field requires exclusive locks and table rewrites.",
-                ),
-                Help(
-                    "Make the field nullable.",
-                ),
-            ],
-        },
     ],
 )


### PR DESCRIPTION
There is another rule that warns about the default in pg <11 that we
ignore here.

Should probably remove those pre pg-11 rules at some point.

rel: https://github.com/sbdchd/squawk/issues/136