### PR TITLE
fix(parse): support SQLValueFunction

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -597,6 +597,7 @@ pub enum AlterTableDef {
     #[serde(rename = "A_Const")]
     Constant(Value),
     ReplicaIdentityStmt(Value),
+    SQLValueFunction(Value),
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -1054,6 +1054,16 @@ CREATE CAST (bigint AS int4) WITH FUNCTION int4(bigint) AS ASSIGNMENT;
     }
 
     #[test]
+    fn test_alter_column_default_with_function() {
+        let sql = r#"
+        ALTER TABLE "table_name" ALTER COLUMN "column_name" SET DEFAULT CURRENT_TIMESTAMP;
+        "#;
+        let res = parse_sql_query(sql);
+        assert!(matches!(res, Ok(_)));
+        assert_debug_snapshot!(res);
+    }
+
+    #[test]
     fn test_create_transform_stmt() {
         let sql = r#"
 CREATE TRANSFORM FOR hstore LANGUAGE plpythonu (

--- a/parser/src/snapshots/squawk_parser__parse__tests__alter_column_default_with_function.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__alter_column_default_with_function.snap
@@ -1,0 +1,60 @@
+---
+source: parser/src/parse.rs
+expression: res
+---
+Ok(
+    [
+        RawStmt(
+            RawStmt {
+                stmt: AlterTableStmt(
+                    AlterTableStmt {
+                        cmds: [
+                            AlterTableCmd(
+                                AlterTableCmd {
+                                    subtype: ColumnDefault,
+                                    name: Some(
+                                        "column_name",
+                                    ),
+                                    def: Some(
+                                        SQLValueFunction(
+                                            Object({
+                                                "location": Number(
+                                                    73,
+                                                ),
+                                                "op": Number(
+                                                    3,
+                                                ),
+                                                "typmod": Number(
+                                                    -1,
+                                                ),
+                                            }),
+                                        ),
+                                    ),
+                                    behavior: Restrict,
+                                    missing_ok: false,
+                                },
+                            ),
+                        ],
+                        relation: RangeVar(
+                            RangeVar {
+                                catalogname: None,
+                                schemaname: None,
+                                relname: "table_name",
+                                inh: true,
+                                relpersistence: "p",
+                                alias: None,
+                                location: 21,
+                            },
+                        ),
+                        relkind: Table,
+                        missing_ok: false,
+                    },
+                ),
+                stmt_location: 0,
+                stmt_len: Some(
+                    90,
+                ),
+            },
+        ),
+    ],
+)


### PR DESCRIPTION
Running Squawk on the following SQL statement

`alter table if exists foo alter column created_at set default current_timestamp`,

errors out with

```
Problem linting SQL files: Squawk schema failed to parse Postgres response. This indicates a bug with Squawk. Please report this error to https://github.com/sbdchd/squawk. Schema error: unknown variant `SQLValueFunction`, expected one of `TypeCast`, `FuncCall`, `Constraint`, `ColumnDef`, `A_Const`, `ReplicaIdentityStmt` at line 1 column 267
```

This PR adds the alter table command definition `SQLValueFunction` to the parser.