### PR TITLE
fix(rules): require concurrent index creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,7 +1569,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "atty",
  "base64 0.12.3",
@@ -1587,7 +1587,7 @@ dependencies = [
 
 [[package]]
 name = "squawk-github"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "jsonwebtoken",
  "log",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "squawk-linter"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "insta",
  "lazy_static",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "squawk-parser"
-version = "0.7.0"
+version = "0.7.2"
 dependencies = [
  "insta",
  "libpg_query-sys",


### PR DESCRIPTION
We weren't checking what type of drop was happening, so any drop stmt that
wasn't marked concurrent was causing an error.

https://github.com/sbdchd/squawk/issues/151
https://github.com/sbdchd/squawk/issues/152
https://github.com/sbdchd/squawk/issues/156