### PR TITLE
fix(ban-drop-column): copy pasta of rename-table row issue

### DIFF
--- a/linter/src/rules/ban_drop_column.rs
+++ b/linter/src/rules/ban_drop_column.rs
@@ -1,21 +1,11 @@
 use crate::violations::{RuleViolation, RuleViolationKind};
-use squawk_parser::ast::{AlterTableCmds, AlterTableType, ObjectType, RootStmt, Stmt};
+use squawk_parser::ast::{AlterTableCmds, AlterTableType, RootStmt, Stmt};
 
 #[must_use]
 pub fn ban_drop_column(tree: &[RootStmt]) -> Vec<RuleViolation> {
     let mut errs = vec![];
     for RootStmt::RawStmt(raw_stmt) in tree {
         match &raw_stmt.stmt {
-            Stmt::RenameStmt(stmt) => match stmt.rename_type {
-                ObjectType::Table => {
-                    errs.push(RuleViolation::new(
-                        RuleViolationKind::RenamingTable,
-                        raw_stmt.into(),
-                        None,
-                    ));
-                }
-                _ => continue,
-            },
             Stmt::AlterTableStmt(stmt) => {
                 for cmd in &stmt.cmds {
                     let AlterTableCmds::AlterTableCmd(cmd) = cmd;

--- a/linter/src/rules/snapshots/squawk_linter__rules__renaming_table__test_rules__renaming_table.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__renaming_table__test_rules__renaming_table.snap
@@ -18,19 +18,5 @@ Ok(
                 ),
             ],
         },
-        RuleViolation {
-            kind: RenamingTable,
-            span: Span {
-                start: 0,
-                len: Some(
-                    52,
-                ),
-            },
-            messages: [
-                Note(
-                    "Renaming a table may break existing clients.",
-                ),
-            ],
-        },
     ],
 )


### PR DESCRIPTION
This rule copied some of rename-table by mistake, which was causing
issues in https://github.com/sbdchd/squawk/issues/166