### PR TITLE
fix(parser): parsing create index with no name

### DIFF
--- a/foo.sql
+++ b/foo.sql
@@ -1,1 +1,0 @@
-ALTER TABLE table_name RENAME TO new_table_name;

--- a/foo.sql
+++ b/foo.sql
@@ -1,0 +1,1 @@
+ALTER TABLE table_name RENAME TO new_table_name;

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -241,7 +241,8 @@ pub struct IndexStmt {
     #[serde(rename = "accessMethod")]
     pub access_method: String,
     /// name of new index, or NULL for default
-    pub idxname: String,
+    #[serde(default)]
+    pub idxname: Option<String>,
     #[serde(rename = "indexParams")]
     pub index_params: Vec<IndexParams>,
     /// relation to build index on

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -77,6 +77,14 @@ mod tests {
     }
 
     #[test]
+    fn create_index_without_index_name() {
+        let sql = "CREATE INDEX ON FOO(BAR);";
+        let res = parse_sql_query(sql);
+        assert!(res.is_ok());
+        assert_debug_snapshot!(res);
+    }
+
+    #[test]
     fn test_error_paths() {
         let sql = r#"lsakdjf;asdlfkjasd;lfj"#;
         let res = parse_sql_query(sql);

--- a/parser/src/snapshots/squawk_parser__parse__tests__adding_index_non_concurrently.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__adding_index_non_concurrently.snap
@@ -9,7 +9,9 @@ Ok(
                 stmt: IndexStmt(
                     IndexStmt {
                         access_method: "btree",
-                        idxname: "field_name_idx",
+                        idxname: Some(
+                            "field_name_idx",
+                        ),
                         index_params: [
                             IndexElem(
                                 IndexElem {
@@ -58,7 +60,9 @@ Ok(
                 stmt: IndexStmt(
                     IndexStmt {
                         access_method: "btree",
-                        idxname: "field_name_idx",
+                        idxname: Some(
+                            "field_name_idx",
+                        ),
                         index_params: [
                             IndexElem(
                                 IndexElem {

--- a/parser/src/snapshots/squawk_parser__parse__tests__create_index_without_index_name.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__create_index_without_index_name.snap
@@ -9,14 +9,12 @@ Ok(
                 stmt: IndexStmt(
                     IndexStmt {
                         access_method: "btree",
-                        idxname: Some(
-                            "table_name_idx",
-                        ),
+                        idxname: None,
                         index_params: [
                             IndexElem(
                                 IndexElem {
                                     name: Some(
-                                        "table_field",
+                                        "bar",
                                     ),
                                     expr: None,
                                     indexcolname: None,
@@ -31,14 +29,14 @@ Ok(
                             RangeVar {
                                 catalogname: None,
                                 schemaname: None,
-                                relname: "table_name",
+                                relname: "foo",
                                 inh: true,
                                 relpersistence: "p",
                                 alias: None,
-                                location: 46,
+                                location: 16,
                             },
                         ),
-                        concurrent: true,
+                        concurrent: false,
                         unique: false,
                         primary: false,
                         isconstraint: false,
@@ -51,7 +49,7 @@ Ok(
                 ),
                 stmt_location: 0,
                 stmt_len: Some(
-                    74,
+                    24,
                 ),
             },
         ),

--- a/parser/src/snapshots/squawk_parser__parse__tests__json_index_operator.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__json_index_operator.snap
@@ -9,7 +9,9 @@ Ok(
                 stmt: IndexStmt(
                     IndexStmt {
                         access_method: "btree",
-                        idxname: "idx_a_foo_bar",
+                        idxname: Some(
+                            "idx_a_foo_bar",
+                        ),
                         index_params: [
                             IndexElem(
                                 IndexElem {

--- a/parser/src/snapshots/squawk_parser__parse__tests__migration.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__migration.snap
@@ -22,7 +22,9 @@ Ok(
                 stmt: IndexStmt(
                     IndexStmt {
                         access_method: "btree",
-                        idxname: "table_name_field_name_idx",
+                        idxname: Some(
+                            "table_name_field_name_idx",
+                        ),
                         index_params: [
                             IndexElem(
                                 IndexElem {
@@ -71,7 +73,9 @@ Ok(
                 stmt: IndexStmt(
                     IndexStmt {
                         access_method: "btree",
-                        idxname: "table_name_field_name_idx",
+                        idxname: Some(
+                            "table_name_field_name_idx",
+                        ),
                         index_params: [
                             IndexElem(
                                 IndexElem {

--- a/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_create_index.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parse_sql_create_index.snap
@@ -9,7 +9,9 @@ Ok(
                 stmt: IndexStmt(
                     IndexStmt {
                         access_method: "btree",
-                        idxname: "table_name_idx",
+                        idxname: Some(
+                            "table_name_idx",
+                        ),
                         index_params: [
                             IndexElem(
                                 IndexElem {

--- a/parser/src/snapshots/squawk_parser__parse__tests__parsing_create_table.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parsing_create_table.snap
@@ -509,7 +509,9 @@ Ok(
                 stmt: IndexStmt(
                     IndexStmt {
                         access_method: "btree",
-                        idxname: "age_index",
+                        idxname: Some(
+                            "age_index",
+                        ),
                         index_params: [
                             IndexElem(
                                 IndexElem {


### PR DESCRIPTION
We don't actually use this field in the AST so we could remove it, but
might as well keep it around for later.

related: https://github.com/sbdchd/squawk/issues/167