### PR TITLE
Add auto exclude based on pg version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,7 +1567,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "atty",
  "base64 0.12.3",

--- a/cli/src/snapshots/squawk__reporter__test_reporter__display_violations_tty.snap.new
+++ b/cli/src/snapshots/squawk__reporter__test_reporter__display_violations_tty.snap.new
@@ -1,0 +1,36 @@
+---
+source: cli/src/reporter.rs
+expression: "strip_ansi_codes(&String::from_utf8_lossy(&buff))"
+---
+main.sql:1:0: warning: adding-not-nullable-field
+
+   1 |  
+   2 |    ALTER TABLE "core_recipe" ADD COLUMN "foo" integer NOT NULL;
+
+  note: Adding a NOT NULL field requires exclusive locks and table rewrites.
+  help: Make the field nullable.
+
+main.sql:1:0: warning: adding-not-nullable-field
+
+   1 |  
+   2 |    ALTER TABLE "core_recipe" ADD COLUMN "foo" integer NOT NULL;
+
+  note: Adding a NOT NULL field requires exclusive locks and table rewrites.
+  help: Make the field nullable.
+
+main.sql:3:1: warning: adding-not-nullable-field
+
+   3 | ALTER TABLE "core_foo" ADD COLUMN "bar" integer NOT NULL;
+
+  note: Adding a NOT NULL field requires exclusive locks and table rewrites.
+  help: Make the field nullable.
+
+main.sql:3:1: warning: adding-not-nullable-field
+
+   3 | ALTER TABLE "core_foo" ADD COLUMN "bar" integer NOT NULL;
+
+  note: Adding a NOT NULL field requires exclusive locks and table rewrites.
+  help: Make the field nullable.
+
+find detailed examples and solutions for each rule at https://squawkhq.com/docs/rules
+

--- a/cli/src/snapshots/squawk__reporter__test_reporter__span_offsets.snap.new
+++ b/cli/src/snapshots/squawk__reporter__test_reporter__span_offsets.snap.new
@@ -1,0 +1,74 @@
+---
+source: cli/src/reporter.rs
+expression: "pretty_violations(violations, sql, filename)"
+---
+ViolationContent {
+    filename: "main.sql",
+    sql: "\n\n   ALTER TABLE \"core_recipe\" ADD COLUMN \"foo\" integer NOT NULL;\nALTER TABLE \"core_foo\" ADD COLUMN \"bar\" integer NOT NULL;\nSELECT 1;\n",
+    violations: [
+        ReportViolation {
+            file: "main.sql",
+            line: 1,
+            column: 2,
+            level: Warning,
+            messages: [
+                Note(
+                    "Adding a NOT NULL field requires exclusive locks and table rewrites.",
+                ),
+                Help(
+                    "Make the field nullable.",
+                ),
+            ],
+            rule_name: AddingNotNullableField,
+            sql: "   ALTER TABLE \"core_recipe\" ADD COLUMN \"foo\" integer NOT NULL;",
+        },
+        ReportViolation {
+            file: "main.sql",
+            line: 1,
+            column: 2,
+            level: Warning,
+            messages: [
+                Note(
+                    "Adding a NOT NULL field requires exclusive locks and table rewrites.",
+                ),
+                Help(
+                    "Make the field nullable.",
+                ),
+            ],
+            rule_name: AddingNotNullableField,
+            sql: "   ALTER TABLE \"core_recipe\" ADD COLUMN \"foo\" integer NOT NULL;",
+        },
+        ReportViolation {
+            file: "main.sql",
+            line: 4,
+            column: 1,
+            level: Warning,
+            messages: [
+                Note(
+                    "Adding a NOT NULL field requires exclusive locks and table rewrites.",
+                ),
+                Help(
+                    "Make the field nullable.",
+                ),
+            ],
+            rule_name: AddingNotNullableField,
+            sql: "ALTER TABLE \"core_foo\" ADD COLUMN \"bar\" integer NOT NULL;",
+        },
+        ReportViolation {
+            file: "main.sql",
+            line: 4,
+            column: 1,
+            level: Warning,
+            messages: [
+                Note(
+                    "Adding a NOT NULL field requires exclusive locks and table rewrites.",
+                ),
+                Help(
+                    "Make the field nullable.",
+                ),
+            ],
+            rule_name: AddingNotNullableField,
+            sql: "ALTER TABLE \"core_foo\" ADD COLUMN \"bar\" integer NOT NULL;",
+        },
+    ],
+}

--- a/linter/src/lib.rs
+++ b/linter/src/lib.rs
@@ -8,11 +8,11 @@ extern crate lazy_static;
 
 use crate::errors::CheckSqlError;
 use crate::rules::{
-    adding_field_with_default, adding_foreign_key_constraint, adding_not_nullable_field,
-    adding_primary_key_constraint, ban_char_type, ban_drop_column, ban_drop_database,
-    changing_column_type, constraint_missing_not_valid, disallow_unique_constraint,
-    prefer_robust_stmts, prefer_text_field, renaming_column, renaming_table,
-    require_concurrent_index_creation, require_concurrent_index_deletion,
+    adding_field_with_default, adding_foreign_key_constraint, adding_not_null_with_default,
+    adding_not_nullable_field, adding_primary_key_constraint, ban_char_type, ban_drop_column,
+    ban_drop_database, changing_column_type, constraint_missing_not_valid,
+    disallow_unique_constraint, prefer_robust_stmts, prefer_text_field, renaming_column,
+    renaming_table, require_concurrent_index_creation, require_concurrent_index_deletion,
 };
 use crate::violations::{RuleViolation, RuleViolationKind, ViolationMessage};
 use squawk_parser::ast::RawStmt;
@@ -55,6 +55,18 @@ lazy_static! {
             ),
             ViolationMessage::Help("Add NOT VALID to the constraint in one transaction and then VALIDATE the constraint in a separate transaction.".into()),
         ]
+    },
+    SquawkRule {
+        id: "adding-not-null-with-default".into(),
+        name: RuleViolationKind::AddingNotNullWithDefault,
+        func: adding_not_null_with_default,
+        messages: vec![
+            // https://www.postgresql.org/docs/10/sql-altertable.html
+            ViolationMessage::Note(
+                "Adding a NOT NULL field requires exclusive locks and table rewrites.".into(),
+            ),
+            ViolationMessage::Help("Make the field nullable.".into())
+        ],
     },
     // usually paired with a DEFAULT
     SquawkRule {

--- a/linter/src/rules/adding_not_null_field.rs
+++ b/linter/src/rules/adding_not_null_field.rs
@@ -64,7 +64,14 @@ mod test_rules {
         let sql = r#"
 ALTER TABLE "core_recipe" ALTER COLUMN "foo" SET NOT NULL;
         "#;
-        let res = check_sql(sql, &["prefer-robust-stmts".into()]).unwrap();
+        let res = check_sql(
+            sql,
+            &[
+                "prefer-robust-stmts".into(),
+                "adding-not-null-with-default".into(),
+            ],
+        )
+        .unwrap();
         assert_eq!(res.len(), 1);
         assert_eq!(res[0].kind, RuleViolationKind::AddingNotNullableField);
         assert_eq!(
@@ -90,14 +97,26 @@ ALTER TABLE "core_recipe" ALTER COLUMN "foo" DROP DEFAULT;
 COMMIT;
         "#;
 
-        assert_debug_snapshot!(check_sql(bad_sql, &["prefer-robust-stmts".into()]));
+        assert_debug_snapshot!(check_sql(
+            bad_sql,
+            &[
+                "prefer-robust-stmts".into(),
+                "adding-not-null-with-default".into()
+            ]
+        ));
 
         let bad_sql = r#"
 -- not sure how this would ever work, but might as well test it
 ALTER TABLE "core_recipe" ADD COLUMN "foo" integer NOT NULL;
         "#;
 
-        assert_debug_snapshot!(check_sql(bad_sql, &["prefer-robust-stmts".into()]));
+        assert_debug_snapshot!(check_sql(
+            bad_sql,
+            &[
+                "prefer-robust-stmts".into(),
+                "adding-not-null-with-default".into()
+            ]
+        ));
     }
 
     #[test]
@@ -106,7 +125,13 @@ ALTER TABLE "core_recipe" ADD COLUMN "foo" integer NOT NULL;
 ALTER TABLE "foo_tbl" ADD COLUMN IF NOT EXISTS "bar_col" TEXT DEFAULT 'buzz' NOT NULL;
 "#;
         assert_eq!(
-            check_sql(ok_sql, &["adding-field-with-default".into()]),
+            check_sql(
+                ok_sql,
+                &[
+                    "adding-field-with-default".into(),
+                    "adding-not-null-with-default".into()
+                ]
+            ),
             Ok(vec![])
         );
     }

--- a/linter/src/rules/adding_not_null_with_default.rs
+++ b/linter/src/rules/adding_not_null_with_default.rs
@@ -1,0 +1,54 @@
+use crate::violations::{RuleViolation, RuleViolationKind, ViolationMessage};
+use squawk_parser::ast::{
+  AlterTableCmds, AlterTableDef, AlterTableType, ColumnDefConstraint, ConstrType, RawStmt, Stmt,
+};
+
+#[must_use]
+pub fn adding_not_null_with_default(tree: &[RawStmt]) -> Vec<RuleViolation> {
+  let mut errs = vec![];
+  for raw_stmt in tree {
+    match &raw_stmt.stmt {
+      Stmt::AlterTableStmt(stmt) => {
+        for AlterTableCmds::AlterTableCmd(cmd) in &stmt.cmds {
+          if cmd.subtype == AlterTableType::AddColumn {
+            if let Some(AlterTableDef::ColumnDef(column_def)) = &cmd.def {
+              for ColumnDefConstraint::Constraint(constraint) in &column_def.constraints {
+                if constraint.contype == ConstrType::NotNull {
+                  errs.push(RuleViolation::new(
+                    RuleViolationKind::AddingNotNullWithDefault,
+                    raw_stmt.into(),
+                    Some(vec![
+                      ViolationMessage::Note(
+                        "Adding a column with a not null default is only safe in PG versions > 11."
+                          .into(),
+                      ),
+                      ViolationMessage::Help(
+                        "For older versions first add the column, then change the default.".into(),
+                      ),
+                    ]),
+                  ));
+                }
+              }
+            }
+          }
+        }
+      }
+      _ => continue,
+    }
+  }
+  errs
+}
+
+#[cfg(test)]
+mod test_rules {
+  use crate::check_sql;
+  use insta::assert_debug_snapshot;
+
+  #[test]
+  fn do_not_allow_not_null_field_with_default() {
+    let bad_sql = r#"
+ALTER TABLE "foo_tbl" ADD COLUMN IF NOT EXISTS "bar_col" TEXT DEFAULT 'buzz' NOT NULL;
+"#;
+    assert_debug_snapshot!(check_sql(bad_sql, &["adding-field-with-default".into()]));
+  }
+}

--- a/linter/src/rules/mod.rs
+++ b/linter/src/rules/mod.rs
@@ -2,6 +2,8 @@ pub mod adding_field_with_default;
 pub use adding_field_with_default::*;
 pub mod adding_not_null_field;
 pub use adding_not_null_field::*;
+pub mod adding_not_null_with_default;
+pub use adding_not_null_with_default::*;
 pub mod adding_primary_key_constraint;
 pub use adding_primary_key_constraint::*;
 pub mod bad_drop_database;

--- a/linter/src/rules/snapshots/squawk_linter__rules__adding_not_null_with_default__test_rules__do_not_allow_not_null_field_with_default.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__adding_not_null_with_default__test_rules__do_not_allow_not_null_field_with_default.snap
@@ -1,0 +1,25 @@
+---
+source: linter/src/rules/adding_not_null_with_default.rs
+expression: "check_sql(bad_sql, &[\"adding-field-with-default\".into()])"
+---
+Ok(
+    [
+        RuleViolation {
+            kind: AddingNotNullWithDefault,
+            span: Span {
+                start: 0,
+                len: Some(
+                    86,
+                ),
+            },
+            messages: [
+                Note(
+                    "Adding a column with a not null default is only safe in PG versions > 11.",
+                ),
+                Help(
+                    "For older versions first add the column, then change the default.",
+                ),
+            ],
+        },
+    ],
+)

--- a/linter/src/violations.rs
+++ b/linter/src/violations.rs
@@ -11,6 +11,7 @@ pub enum RuleViolationKind {
     AddingForeignKeyConstraint,
     ChangingColumnType,
     AddingNotNullableField,
+    AddingNotNullWithDefault,
     AddingSerialPrimaryKeyField,
     RenamingColumn,
     RenamingTable,

--- a/parser/src/snapshots/squawk_parser__parse__tests__adding_index_non_concurrently.snap.new
+++ b/parser/src/snapshots/squawk_parser__parse__tests__adding_index_non_concurrently.snap.new
@@ -1,0 +1,131 @@
+---
+source: parser/src/parse.rs
+expression: res
+---
+Ok(
+    [
+        RawStmt {
+            stmt: CommentStmt(
+                Object({
+                    "comment": String(
+                        "This is my table.",
+                    ),
+                    "object": Object({
+                        "List": Object({
+                            "items": Array([
+                                Object({
+                                    "String": Object({
+                                        "str": String(
+                                            "mytable",
+                                        ),
+                                    }),
+                                }),
+                            ]),
+                        }),
+                    }),
+                    "objtype": String(
+                        "OBJECT_TABLE",
+                    ),
+                }),
+            ),
+            stmt_location: 0,
+            stmt_len: Some(
+                66,
+            ),
+        },
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    access_method: "btree",
+                    idxname: Some(
+                        "field_name_idx",
+                    ),
+                    index_params: [
+                        IndexElem(
+                            IndexElem {
+                                name: Some(
+                                    "field_name",
+                                ),
+                                expr: None,
+                                indexcolname: None,
+                                collation: None,
+                                opclass: [],
+                                ordering: Default,
+                                nulls_ordering: Default,
+                            },
+                        ),
+                    ],
+                    relation: RangeVar {
+                        catalogname: None,
+                        schemaname: None,
+                        relname: "table_name",
+                        inh: true,
+                        relpersistence: "p",
+                        alias: None,
+                        location: 103,
+                    },
+                    concurrent: false,
+                    unique: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    if_not_exists: false,
+                    table_space: None,
+                },
+            ),
+            stmt_location: 67,
+            stmt_len: Some(
+                63,
+            ),
+        },
+        RawStmt {
+            stmt: IndexStmt(
+                IndexStmt {
+                    access_method: "btree",
+                    idxname: Some(
+                        "field_name_idx",
+                    ),
+                    index_params: [
+                        IndexElem(
+                            IndexElem {
+                                name: Some(
+                                    "field_name",
+                                ),
+                                expr: None,
+                                indexcolname: None,
+                                collation: None,
+                                opclass: [],
+                                ordering: Default,
+                                nulls_ordering: Default,
+                            },
+                        ),
+                    ],
+                    relation: RangeVar {
+                        catalogname: None,
+                        schemaname: None,
+                        relname: "table_name",
+                        inh: true,
+                        relpersistence: "p",
+                        alias: None,
+                        location: 202,
+                    },
+                    concurrent: true,
+                    unique: false,
+                    primary: false,
+                    isconstraint: false,
+                    deferrable: false,
+                    initdeferred: false,
+                    transformed: false,
+                    if_not_exists: false,
+                    table_space: None,
+                },
+            ),
+            stmt_location: 131,
+            stmt_len: Some(
+                98,
+            ),
+        },
+    ],
+)


### PR DESCRIPTION
Do we want to simply exclude rules, or actually be aware of the pg version within the linter?