### PR TITLE
enable GitHub UI button to allow CI to run for outside contributors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Rust CI
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build-linux:


### PR DESCRIPTION
We need to enable builds on "pull_request" for GitHub to display a button to allow CI for non-members