### PR TITLE
docs: add padding below features

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -158,7 +158,7 @@ function Home() {
         {features && features.length > 0 && (
           <section className={styles.features}>
             <div className="container">
-              <div className="row">
+              <div className="row" style={{paddingBottom: '2rem'}}>
                 {features.map((props, idx) => (
                   <Feature key={idx} {...props} />
                 ))}


### PR DESCRIPTION
Before

<img width="1392" alt="Screen Shot 2022-03-28 at 9 06 11 AM" src="https://user-images.githubusercontent.com/1929960/160404258-1cb5ea34-995e-4564-a7d5-5af82bb7113b.png">

After

<img width="1392" alt="Screen Shot 2022-03-28 at 9 05 59 AM" src="https://user-images.githubusercontent.com/1929960/160404262-6834a2d5-8d5a-40a3-909c-2148c28d83ed.png">
