### PR TITLE
pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+- id: squawk
+  name: squawk
+  description: 'Linter for Postgres migrations'
+  entry: squawk
+  language: node
+  types: 
+    - text
+  additional_dependencies: 
+    - squawk-cli

--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ Here's an example comment created by `squawk` using the `example.sql` in the rep
 
 See the ["GitHub Integration" docs](https://squawkhq.com/docs/github_app) for more information.
 
+## `pre-commit` hook
+
+Integrate Squawk into Git workflow with [pre-commit](https://pre-commit.com/). Add the following
+to your project's `.pre-commit-config.yaml`:
+
+```
+repos:
+  - repo: https://github.com/sbdchd/squawk
+    rev: v0.10.0
+    hooks:
+     - id: squawk
+       files: path/to/postres/migrations/written/in/sql
+```
+
+Note the `files` parameter as it specifies the location of the files to be linted.
+
 ## prior art
 
 - <https://github.com/erik/squabble>


### PR DESCRIPTION
Adds the ability to use Squawk with `pre-commit` (https://pre-commit.com/). I tried referencing this in a local project and it worked. Happy to provide any additional context that might be useful.