### PR TITLE
fix actions auth creating duplicate messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.11.1 - 2022-05-11
+
+## Fixed
+
+- duplicate messages being written when using GitHub Actions token authentication. (#209)
+
 ## v0.11.0 - 2022-05-11
 
 ## Added
 
-- Support GitHub API authentication via GitHub Actions tokens.
+- Support GitHub API authentication via GitHub Actions tokens. (#207)
 
 ## v0.10.0 - 2022-04-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "atty",
  "base64 0.12.3",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squawk"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/github/src/app.rs
+++ b/github/src/app.rs
@@ -196,7 +196,7 @@ impl GitHub {
         let access_token = create_access_token(&jwt, installation_id)?;
 
         Ok(GitHub {
-            slug_name: app_info.slug,
+            slug_name: format!("{}[bot]", app_info.slug),
             installation_access_token: access_token.token,
         })
     }

--- a/github/src/lib.rs
+++ b/github/src/lib.rs
@@ -61,7 +61,7 @@ pub fn comment_on_pr(
 ) -> Result<(), GithubError> {
     let comments = gh.list_issue_comments(owner, repo, issue)?;
 
-    let bot_name = format!("{}[bot]", gh.app_slug());
+    let bot_name = gh.app_slug();
 
     info!("checking for existing comment");
     match comments

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squawk-cli",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "linter for PostgreSQL, focused on migrations",
   "repository": "git@github.com:sbdchd/squawk.git",
   "author": "Steve Dignam <steve@dignam.xyz>",


### PR DESCRIPTION
Our slug name was incorrect for GitHub Actions authentication, so duplicate messages were being written.