### PR TITLE
Add support for configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,6 +1622,7 @@ dependencies = [
  "base64 0.12.3",
  "console 0.11.3",
  "insta",
+ "lazy_static",
  "log",
  "serde",
  "serde_json",
@@ -1630,6 +1631,7 @@ dependencies = [
  "squawk-linter",
  "squawk-parser",
  "structopt",
+ "toml",
 ]
 
 [[package]]
@@ -1983,6 +1985,15 @@ dependencies = [
  "futures",
  "slab",
  "tokio-executor",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,7 +1622,6 @@ dependencies = [
  "base64 0.12.3",
  "console 0.11.3",
  "insta",
- "lazy_static",
  "log",
  "serde",
  "serde_json",

--- a/README.md
+++ b/README.md
@@ -118,15 +118,17 @@ Rules can also be disabled by using a configuration file, which can be used via 
 ```shell
 squawk --config=~/.squawk.toml example.sql
 ```
+
 The `--exclude` flag will always be prioritized over the configuration file
 
 If the config flag it's not present or the file doesn't exist, squawk will try to look for a configuration file automatically at these locations (ordered by priority):
 
 1.  `./.squawk.toml`
-2. `$GIT_REPO_ROOT/.squawk.toml`
-3. `~/.squawk.toml`
+2.  `$GIT_REPO_ROOT/.squawk.toml`
+3.  `~/.squawk.toml`
 
 **Example `.squawk.toml`**
+
 ```toml
 excluded_rules = ["require-concurrent-index-creation", "require-concurrent-index-deletion"]
 ```

--- a/README.md
+++ b/README.md
@@ -113,24 +113,23 @@ squawk --exclude=adding-field-with-default,disallowed-unique-constraint example.
 
 ### Configuration file
 
-Rules can also be disabled by using a configuration file, which can be used via the `-c` or `--config` flag
+Rules can also be disabled with a configuration file.
+
+By default, Squawk will traverse up from the current directory to find a `.squawk.toml` configuration file. You may specify a custom path with the `-c` or `--config` flag.
 
 ```shell
 squawk --config=~/.squawk.toml example.sql
 ```
 
-The `--exclude` flag will always be prioritized over the configuration file
-
-If the config flag it's not present or the file doesn't exist, squawk will try to look for a configuration file automatically at these locations (ordered by priority):
-
-1.  `./.squawk.toml`
-2.  Tries to traverses back directories up to a depth of 5
-3.  `~/.squawk.toml`
+The `--exclude` flag will always be prioritized over the configuration file.
 
 **Example `.squawk.toml`**
 
 ```toml
-excluded_rules = ["require-concurrent-index-creation", "require-concurrent-index-deletion"]
+excluded_rules = [
+    "require-concurrent-index-creation",
+    "require-concurrent-index-deletion",
+]
 ```
 
 See the [Squawk website](https://squawkhq.com/docs/rules) for documentation on each rule with examples and reasoning.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The `--exclude` flag will always be prioritized over the configuration file
 If the config flag it's not present or the file doesn't exist, squawk will try to look for a configuration file automatically at these locations (ordered by priority):
 
 1.  `./.squawk.toml`
-2.  `$GIT_REPO_ROOT/.squawk.toml`
+2.  Tries to traverses back directories up to a depth of 5
 3.  `~/.squawk.toml`
 
 **Example `.squawk.toml`**

--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ Individual rules can be disabled via the `--exclude` flag
 squawk --exclude=adding-field-with-default,disallowed-unique-constraint example.sql
 ```
 
+### Configuration file
+
+Rules can also be disabled by using a configuration file, which can be used via the `-c` or `--config` flag
+
+```shell
+squawk --config=~/.squawk.toml example.sql
+```
+The `--exclude` flag will always be prioritized over the configuration file
+
+If the config flag it's not present or the file doesn't exist, squawk will try to look for a configuration file automatically at these locations (ordered by priority):
+
+1.  `./.squawk.toml`
+2. `$GIT_REPO_ROOT/.squawk.toml`
+3. `~/.squawk.toml`
+
+**Example `.squawk.toml`**
+```toml
+excluded_rules = ["require-concurrent-index-creation", "require-concurrent-index-deletion"]
+```
+
 See the [Squawk website](https://squawkhq.com/docs/rules) for documentation on each rule with examples and reasoning.
 
 ## Bot Setup

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,8 @@ log = "0.4.8"
 squawk-parser = { version = "0.0.0", path = "../parser" }
 squawk-linter = { version = "0.0.0", path = "../linter" }
 squawk-github = { version = "0.0.0", path = "../github" }
+toml = "0.5.9"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -26,7 +26,6 @@ squawk-parser = { version = "0.0.0", path = "../parser" }
 squawk-linter = { version = "0.0.0", path = "../linter" }
 squawk-github = { version = "0.0.0", path = "../github" }
 toml = "0.5.9"
-lazy_static = "1.4.0"
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,0 +1,66 @@
+use lazy_static::lazy_static;
+use log::info;
+use serde::Deserialize;
+use std::{char, path::Path, process::Command};
+
+const FILE_NAME: &str = ".squawk.toml";
+lazy_static! {
+    static ref STATIC_SEARCH_PATHS: Vec<String> =
+        vec![format!("./{}", FILE_NAME), format!("~/{}", FILE_NAME)];
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct Config {
+    pub excluded_rules: Option<Vec<String>>,
+}
+
+impl Config {
+    pub fn parse(custom_path: Option<String>) -> Option<Self> {
+        let path = custom_path.or_else(Self::find_path);
+
+        if let Some(p) = path {
+            info!("config file path: {}", &p);
+            if Path::new(&p).exists() {
+                if let Ok(file_content) = std::fs::read_to_string(p) {
+                    return toml::from_str(&file_content).ok();
+                }
+            }
+        }
+
+        info!("no config file found");
+        None
+    }
+
+    fn find_path() -> Option<String> {
+        let static_path = STATIC_SEARCH_PATHS
+            .iter()
+            .find(|p| Path::new(p).exists())
+            .map(|p| p.to_string());
+
+        // Config in git root takes priority after the local directory config
+        match (&static_path, get_git_root_config_path()) {
+            (Some(sp), Some(git_root_config_path)) => {
+                if sp != &STATIC_SEARCH_PATHS[0] {
+                    Some(git_root_config_path)
+                } else {
+                    static_path
+                }
+            }
+            (None, Some(git_root_config_path)) => Some(git_root_config_path),
+            _ => static_path,
+        }
+    }
+}
+
+fn get_git_root_config_path() -> Option<String> {
+    let git_root_path = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim_end_matches(char::is_control).to_string());
+
+    git_root_path
+        .map(|grp| format!("{}/{}", grp, FILE_NAME))
+        .filter(|git_root_config_path| Path::new(git_root_config_path).exists())
+}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,73 +1,84 @@
-use lazy_static::lazy_static;
 use log::info;
 use serde::Deserialize;
-use std::{fs, path::Path};
+use std::{env, io, path::PathBuf};
 
 const FILE_NAME: &str = ".squawk.toml";
-lazy_static! {
-    static ref STATIC_SEARCH_PATHS: Vec<String> =
-        vec![format!("./{}", FILE_NAME), format!("~/{}", FILE_NAME)];
+
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug)]
+pub enum ConfigError {
+    LookupError(io::Error),
+    ReadError(io::Error),
+    ParseError(toml::de::Error),
+}
+
+impl std::convert::From<io::Error> for ConfigError {
+    fn from(e: io::Error) -> Self {
+        Self::ReadError(e)
+    }
+}
+
+impl std::convert::From<toml::de::Error> for ConfigError {
+    fn from(e: toml::de::Error) -> Self {
+        Self::ParseError(e)
+    }
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match *self {
+            Self::LookupError(ref err) => {
+                write!(f, "Error when finding configuration file: {}", err)
+            }
+            Self::ReadError(ref err) => write!(f, "Failed to read configuration file: {}", err),
+            Self::ParseError(ref err) => write!(f, "Failed to parse configuration file: {}", err),
+        }
+    }
 }
 
 #[derive(Debug, Default, Deserialize)]
 pub struct Config {
-    pub excluded_rules: Option<Vec<String>>,
+    #[serde(default)]
+    pub excluded_rules: Vec<String>,
 }
 
 impl Config {
-    pub fn parse(custom_path: Option<String>) -> Option<Self> {
-        let path = custom_path.or_else(Self::find_path);
+    pub fn parse(custom_path: Option<PathBuf>) -> Result<Option<Self>, ConfigError> {
+        let path = if let Some(path) = custom_path {
+            Some(path)
+        } else {
+            find_by_traversing_back()?
+        };
 
         if let Some(p) = path {
-            info!("config file path: {}", &p);
-            if Path::new(&p).exists() {
-                if let Ok(file_content) = std::fs::read_to_string(p) {
-                    return toml::from_str(&file_content).ok();
-                }
-            }
+            info!("using config file path: {}", p.display());
+
+            let file_content = std::fs::read_to_string(p)?;
+            return Ok(Some(toml::from_str(&file_content)?));
         }
 
         info!("no config file found");
-        None
-    }
-
-    fn find_path() -> Option<String> {
-        let static_path = STATIC_SEARCH_PATHS
-            .iter()
-            .find(|p| Path::new(p).exists())
-            .map(String::to_string);
-
-        // Config by traversing back takes priority after the local directory config
-        match (&static_path, find_by_traversing_back()) {
-            (Some(sp), Some(alt_path)) => {
-                if sp == &STATIC_SEARCH_PATHS[0] {
-                    static_path
-                } else {
-                    Some(alt_path)
-                }
-            }
-            (None, Some(alt_path)) => Some(alt_path),
-            _ => static_path,
-        }
+        Ok(None)
     }
 }
 
-fn find_by_traversing_back() -> Option<String> {
-    for depth in 1..6 {
-        let dir = "../".repeat(depth);
-        let expected_file = format!("{}{}", dir, FILE_NAME);
-
-        match fs::read_dir(dir) {
-            Ok(dir_entries) => {
-                for f in dir_entries.flatten() {
-                    if f.path().display().to_string() == expected_file {
-                        return Some(expected_file);
-                    }
-                }
-            }
-            _ => return None,
+fn recurse_directory(
+    directory: PathBuf,
+    file_name: &str,
+) -> Result<Option<PathBuf>, std::io::Error> {
+    for entry in directory.read_dir()? {
+        let entry = entry?;
+        if entry.file_name() == file_name {
+            return Ok(Some(entry.path()));
         }
     }
+    if let Some(parent) = directory.parent() {
+        recurse_directory(parent.to_path_buf(), file_name)
+    } else {
+        Ok(None)
+    }
+}
 
-    None
+fn find_by_traversing_back() -> Result<Option<PathBuf>, ConfigError> {
+    recurse_directory(env::current_dir()?, FILE_NAME).map_err(|e| ConfigError::LookupError(e))
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -35,15 +35,15 @@ impl Config {
         let static_path = STATIC_SEARCH_PATHS
             .iter()
             .find(|p| Path::new(p).exists())
-            .map(|p| p.to_string());
+            .map(String::to_string);
 
         // Config in git root takes priority after the local directory config
         match (&static_path, get_git_root_config_path()) {
             (Some(sp), Some(git_root_config_path)) => {
-                if sp != &STATIC_SEARCH_PATHS[0] {
-                    Some(git_root_config_path)
-                } else {
+                if sp == &STATIC_SEARCH_PATHS[0] {
                     static_path
+                } else {
+                    Some(git_root_config_path)
                 }
             }
             (None, Some(git_root_config_path)) => Some(git_root_config_path),

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,10 +1,9 @@
 use log::info;
 use serde::Deserialize;
-use std::{env, io, path::PathBuf};
+use std::{env, io, path::Path, path::PathBuf};
 
 const FILE_NAME: &str = ".squawk.toml";
 
-#[allow(clippy::enum_variant_names)]
 #[derive(Debug)]
 pub enum ConfigError {
     LookupError(io::Error),
@@ -62,10 +61,7 @@ impl Config {
     }
 }
 
-fn recurse_directory(
-    directory: PathBuf,
-    file_name: &str,
-) -> Result<Option<PathBuf>, std::io::Error> {
+fn recurse_directory(directory: &Path, file_name: &str) -> Result<Option<PathBuf>, std::io::Error> {
     for entry in directory.read_dir()? {
         let entry = entry?;
         if entry.file_name() == file_name {
@@ -73,12 +69,12 @@ fn recurse_directory(
         }
     }
     if let Some(parent) = directory.parent() {
-        recurse_directory(parent.to_path_buf(), file_name)
+        recurse_directory(parent, file_name)
     } else {
         Ok(None)
     }
 }
 
 fn find_by_traversing_back() -> Result<Option<PathBuf>, ConfigError> {
-    recurse_directory(env::current_dir()?, FILE_NAME).map_err(|e| ConfigError::LookupError(e))
+    recurse_directory(&env::current_dir()?, FILE_NAME).map_err(ConfigError::LookupError)
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -37,7 +37,7 @@ impl Config {
             .find(|p| Path::new(p).exists())
             .map(String::to_string);
 
-        // Config in git root takes priority after the local directory config
+        // Config by traversing back takes priority after the local directory config
         match (&static_path, find_by_traversing_back()) {
             (Some(sp), Some(alt_path)) => {
                 if sp == &STATIC_SEARCH_PATHS[0] {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::match_wildcard_for_single_variants)]
 #[allow(clippy::non_ascii_literal)]
 #[allow(clippy::cast_sign_loss)]
+#[allow(clippy::enum_variant_names)]
+#[allow(clippy::module_name_repetitions)]
 mod config;
 mod reporter;
 mod subcommand;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,14 +1,18 @@
 #![allow(clippy::match_wildcard_for_single_variants)]
 #[allow(clippy::non_ascii_literal)]
 #[allow(clippy::cast_sign_loss)]
+mod config;
 mod reporter;
 mod subcommand;
+
 use crate::reporter::{
     check_files, dump_ast_for_paths, explain_rule, list_rules, print_violations, DumpAstOption,
     Reporter,
 };
 use crate::subcommand::{check_and_comment_on_pr, Command};
 use atty::Stream;
+use config::Config;
+use log::info;
 use simplelog::CombinedLogger;
 use std::io;
 use std::process;
@@ -55,10 +59,14 @@ struct Opt {
     /// Enable debug logging output
     #[structopt(long)]
     verbose: bool,
+    /// Path to the squawk config file (.squawk.toml)
+    #[structopt(short, long, use_delimiter = true)]
+    config: Option<String>,
 }
 
 fn main() {
     let opts = Opt::from_args();
+
     if opts.verbose {
         CombinedLogger::init(vec![simplelog::TermLogger::new(
             simplelog::LevelFilter::Info,
@@ -69,6 +77,13 @@ fn main() {
         .expect("problem creating logger");
     }
 
+    let conf = Config::parse(opts.config);
+    let excluded_rules = &opts
+        .exclude
+        .or(conf.unwrap_or_default().excluded_rules)
+        .unwrap_or_default();
+    info!("excluded rules: {:?}", &excluded_rules);
+
     let mut clap_app = Opt::clap();
     let stdout = io::stdout();
     let mut handle = stdout.lock();
@@ -76,12 +91,7 @@ fn main() {
     let is_stdin = !atty::is(Stream::Stdin);
     if let Some(subcommand) = opts.cmd {
         exit(
-            check_and_comment_on_pr(
-                subcommand,
-                is_stdin,
-                opts.stdin_filepath,
-                &opts.exclude.unwrap_or_default(),
-            ),
+            check_and_comment_on_pr(subcommand, is_stdin, opts.stdin_filepath, excluded_rules),
             "Upload to GitHub failed",
         );
     } else if !opts.paths.is_empty() || is_stdin {
@@ -91,12 +101,7 @@ fn main() {
                 "Failed to dump AST",
             );
         } else {
-            match check_files(
-                &opts.paths,
-                is_stdin,
-                opts.stdin_filepath,
-                &opts.exclude.unwrap_or_default(),
-            ) {
+            match check_files(&opts.paths, is_stdin, opts.stdin_filepath, excluded_rules) {
                 Ok(file_reports) => {
                     let reporter = opts.reporter.unwrap_or(Reporter::Tty);
                     let total_violations = file_reports

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,7 +60,7 @@ struct Opt {
     #[structopt(long)]
     verbose: bool,
     /// Path to the squawk config file (.squawk.toml)
-    #[structopt(short, long, use_delimiter = true)]
+    #[structopt(short, long)]
     config: Option<String>,
 }
 

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -330,8 +330,10 @@ pub fn pretty_violations(
                 // whitespace for nodes.
                 let Span { start, len } = violation.span;
 
+                #[allow(clippy::cast_sign_loss)]
                 let start = start as usize;
 
+                #[allow(clippy::cast_sign_loss)]
                 let len = len.unwrap_or(0) as usize;
 
                 // 1-indexed

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -3,7 +3,7 @@ id: cli
 title: CLI
 ---
 
-## Usage
+## usage
 
 ```bash
 # lint a file or multiple
@@ -12,6 +12,38 @@ squawk migration_001.sql migration_002.sql migration_003.sql
 # lint from standard in
 cat migration.sql | squawk
 ```
+
+### rules
+
+Individual rules can be disabled via the `--exclude` flag
+
+```shell
+squawk --exclude=adding-field-with-default,disallowed-unique-constraint example.sql
+```
+
+### `.squawk.toml` configuration file
+
+Rules can be disabled with a configuration file.
+
+By default, Squawk will traverse up from the current directory to find a `.squawk.toml` configuration file. You may specify a custom path with the `-c` or `--config` flag.
+
+```shell
+squawk --config=~/.squawk.toml example.sql
+```
+
+The `--exclude` flag will always be prioritized over the configuration file.
+
+**Example `.squawk.toml`**
+
+```toml
+excluded_rules = [
+    "require-concurrent-index-creation",
+    "require-concurrent-index-deletion",
+]
+```
+
+See the [Squawk website](https://squawkhq.com/docs/rules) for documentation on each rule with examples and reasoning.
+
 
 ### `squawk --help`
 
@@ -23,39 +55,42 @@ USAGE:
     squawk [FLAGS] [OPTIONS] [paths]... [SUBCOMMAND]
 
 FLAGS:
-    -h, --help
+    -h, --help          
             Prints help information
 
-        --list-rules
+        --list-rules    
             List all available rules
 
-    -V, --version
+    -V, --version       
             Prints version information
 
-        --verbose
+        --verbose       
             Enable debug logging output
 
 
 OPTIONS:
-        --dump-ast <dump-ast>
+    -c, --config <config-path>               
+            Path to the squawk config file (.squawk.toml)
+
+        --dump-ast <dump-ast>                
             Output AST in JSON [possible values: Raw, Parsed, Debug]
 
-    -e, --exclude <exclude>...
+    -e, --exclude <exclude>...               
             Exclude specific warnings
-
+            
             For example: --exclude=require-concurrent-index-creation,ban-drop-database
-        --explain <explain>
+        --explain <explain>                  
             Provide documentation on the given rule
 
-        --reporter <reporter>
+        --reporter <reporter>                
             Style of error reporting [possible values: Tty, Gcc, Json]
 
-        --stdin-filepath <stdin-filepath>
+        --stdin-filepath <stdin-filepath>    
             Path to use in reporting for stdin
 
 
 ARGS:
-    <paths>...
+    <paths>...    
             Paths to search
 
 


### PR DESCRIPTION
Hello folks 👋 
This PR adds support for the configuration file as proposed https://github.com/sbdchd/squawk/issues/205

### Feature
As discussed in the issue It prioritizes the CLI flag before it starts using the config file, I've also added a CLI flag to specify a custom configuration path (`-c` or `--config`).

The file name is `.squawk.toml` and if a custom path it's not specified or the file specified doesn't exist then it tries to look for the file in the following paths with this priority:

1.  `./.squawk.toml`
2. ~~`$GIT_REPO_ROOT/.squawk.toml`~~ -> Now it traverses back directories up to a depth of 5
3. `~/.squawk.toml`

If not found on any of these paths then the program continues running without a config file.

### Testing
These changes have been tested only on macOS, it would be great if someone wants to test these on Linux, but it should work there as well.

### Final considerations
One case that I have not covered here is if the user wants to use both the CLI flags and the config file, one solution for this case would be to use the `-c`/`--config` flag together with the `--exclude` flag to signal the program that the user wants to merge those two together, but it's not a change that I want to do in this PR and it would be beneficial to reach an agreement with the contributors/community before deciding on a way to handle this case.

Feel free to change anything that you'd like different, I haven't looked much at the other code, and I'm not sure if I'm following the coding style, verbosity frequency, etc...