### PR TITLE
Nixify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,8 +777,8 @@ dependencies = [
 
 [[package]]
 name = "libpg_query-sys"
-version = "0.1.3"
-source = "git+https://github.com/chdsbd/libpg_query-sys?branch=chris/bump-submodule#03b96cf6b8a7df84a62e285835d9ca08a89e4af4"
+version = "0.2.0"
+source = "git+https://github.com/lf-/libpg_query-sys?branch=system-lib#ba0697bf023b3e81d8895d890ae1c650dbd9644f"
 dependencies = [
  "bindgen",
  "make-cmd",

--- a/README.md
+++ b/README.md
@@ -203,6 +203,17 @@ cargo run
 ./s/fmt
 ```
 
+... or with nix:
+
+```
+$ nix develop
+[nix-shell]$ cargo run
+[nix-shell]$ cargo insta review
+[nix-shell]$ ./s/test
+[nix-shell]$ ./s/lint
+[nix-shell]$ ./s/fmt
+```
+
 ### releasing a new version
 
 1. update the CHANGELOG.md and bump version in the cli `Cargo.toml`, ensure the

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1656461576,
+        "narHash": "sha256-rlmmw6lIlkMQIiB+NsnO8wQYWTfle8TA41UREPLP5VY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "cf3ab54b4afe2b7477faa1dd0b65bf74c055d70c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1656065134,
+        "narHash": "sha256-oc6E6ByIw3oJaIyc67maaFcnjYOz1mMcOtHxbEf9NwQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "bee6a7250dd1b01844a2de7e02e4df7d8a0a206c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,69 @@
+{
+  description = "Linter for PostgreSQL, focused on migrations";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, utils }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          # libpg_query has systems = x86_64, which is probably a bug
+          config.allowUnsupportedSystem = true;
+          overlays = [ overlay ];
+        };
+        overlay = (final: prev:
+          let inherit (prev) lib;
+          in
+          {
+            squawk = final.rustPlatform.buildRustPackage {
+              pname = "squawk";
+              version = "0.13.2";
+
+              cargoLock = {
+                lockFile = ./Cargo.lock;
+                outputHashes = {
+                  "libpg_query-sys-0.2.0" = "sha256-Txllwr/aZFrrRC+Me+ofX/B9l7JpX6MBLEs2NX2FFqw=";
+                };
+              };
+
+              src = ./.;
+
+              nativeBuildInputs = with final; [
+                pkg-config
+                rustPlatform.bindgenHook
+              ];
+
+              buildInputs = with final; [
+                libiconv
+                openssl
+              ] ++ lib.optionals final.stdenv.isDarwin (with final.darwin.apple_sdk.frameworks; [
+                CoreFoundation
+                Security
+              ]);
+
+              LIBPG_QUERY = final.libpg_query;
+
+              meta = with lib; {
+                description = "Linter for PostgreSQL, focused on migrations";
+                homepage = "https://github.com/sbdchd/squawk";
+                license = licenses.gpl3Only;
+                platforms = platforms.all;
+              };
+            };
+          });
+      in
+      {
+        packages = {
+          squawk = pkgs.squawk;
+        };
+        defaultPackage = self.packages.${system}.squawk;
+        checks = self.packages;
+
+        # for debugging
+        inherit pkgs;
+
+        devShell = pkgs.squawk;
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,8 @@
         # for debugging
         inherit pkgs;
 
-        devShell = pkgs.squawk;
+        devShell = pkgs.squawk.overrideAttrs (old: {
+          RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+        });
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,10 @@
 
         devShell = pkgs.squawk.overrideAttrs (old: {
           RUST_SRC_PATH = pkgs.rustPlatform.rustLibSrc;
+
+          nativeBuildInputs = old.nativeBuildInputs ++ (with pkgs; [
+            cargo-insta
+          ]);
         });
       });
 }

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["postgres", "sql", "parser"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-libpg_query-sys = { git = "https://github.com/chdsbd/libpg_query-sys", branch= "chris/bump-submodule" }
+libpg_query-sys = { git = "https://github.com/lf-/libpg_query-sys", branch= "system-lib" }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1"


### PR DESCRIPTION
- Update libpg_query-sys to upstream plus
  https://github.com/tdbgamer/libpg_query-sys/pull/4, which adds a
  LIBPG_QUERY environment variable to use a prebuilt libpg_query

  I am following up upstream in nixpkgs to obsolete the
  allowUnsupportedSystem override: https://github.com/NixOS/nixpkgs/pull/179749
- Add a flake.nix file allowing people to build or get a development
  environment with Nix on macOS and Linux (tested on aarch64)

The practical benefit of this PR is that it is now easier to include
squawk in Nix-based development environments if desired.

It can still be used as previously as well; this is fully optional.

Usage:

```
$ nix build
-> creates a result/ symlink with bin/squawk
$ nix develop
-> gets you a shell with rustc and cargo and all the native deps for squawk, so you can develop on it
```