### PR TITLE
prefer-robust-statements: explicitly stop unnamed CREATE INDEX CONCURRENTLY

### DIFF
--- a/docs/docs/prefer-robust-stmts.md
+++ b/docs/docs/prefer-robust-stmts.md
@@ -82,6 +82,25 @@ CREATE INDEX CONCURRENTLY "email_idx" ON "app_user" ("email");
 CREATE INDEX CONCURRENTLY IF NOT EXISTS "email_idx" ON "app_user" ("email");
 ```
 
+`CREATE INDEX CONCURRENTLY` failing will leave behind `INVALID` index objects
+that still occupy their respective names. This means that if a name is not
+specified, a failing migration being run multiple times will create multiple
+duplicate indexes with consecutive names, all of which are `INVALID`.
+
+If you provide a name and `IF NOT EXISTS`, the second run will falsely succeed
+because the index exists, even though it is invalid. This is another footgun,
+albeit a checkable (see the `pg_index` catalog) one.
+
+Thus:
+
+```
+-- instead of:
+CREATE INDEX CONCURRENTLY ON "app_user" ("email");
+
+-- use:
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "email_idx" ON "app_user" ("email");
+```
+
 ### remove table
 
 ```sql

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test_rules__create_index_concurrently_unnamed.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test_rules__create_index_concurrently_unnamed.snap
@@ -1,0 +1,22 @@
+---
+source: linter/src/rules/prefer_robust_stmts.rs
+expression: "check_sql(bad_sql, &[])"
+---
+Ok(
+    [
+        RuleViolation {
+            kind: PreferRobustStmts,
+            span: Span {
+                start: 0,
+                len: Some(
+                    59,
+                ),
+            },
+            messages: [
+                Help(
+                    "Use an explicit name for a concurrently created index",
+                ),
+            ],
+        },
+    ],
+)


### PR DESCRIPTION
This is a problematic construct for the reasons described in
the changes to prefer-robust-stmts.md.

We learned this the hard way 🙃