### PR TITLE
Check for add column using references

### DIFF
--- a/linter/src/rules/adding_foreign_key_constraint.rs
+++ b/linter/src/rules/adding_foreign_key_constraint.rs
@@ -129,4 +129,19 @@ COMMIT;
             RuleViolationKind::AddingForeignKeyConstraint
         );
     }
+    #[test]
+    fn test_add_column_references_lock() {
+        let sql = r#"
+BEGIN;
+ALTER TABLE "emails" ADD COLUMN "user_id" INT REFERENCES "user" ("id");
+COMMIT;
+        "#;
+
+        let violations = lint_sql(sql);
+        assert_eq!(violations.len(), 1);
+        assert_eq!(
+            violations[0].kind,
+            RuleViolationKind::AddingForeignKeyConstraint
+        );
+    }
 }

--- a/linter/src/rules/adding_foreign_key_constraint.rs
+++ b/linter/src/rules/adding_foreign_key_constraint.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 
 use squawk_parser::ast::{
-    AlterTableCmds, AlterTableDef, AlterTableType, ColumnDefConstraint, ConstrType, RawStmt, Stmt, TableElt,
+    AlterTableCmds, AlterTableDef, AlterTableType, ColumnDefConstraint, ConstrType, RawStmt, Stmt,
+    TableElt,
 };
 
 /// Adding a foreign key constraint requires a table scan and a
@@ -54,8 +55,12 @@ pub fn adding_foreign_key_constraint(
                                 }
                             } else if let AlterTableType::AddColumn = command.subtype {
                                 if let Some(AlterTableDef::ColumnDef(column_def)) = &command.def {
-                                    for ColumnDefConstraint::Constraint(constraint) in &column_def.constraints {
-                                        if !constraint.skip_validation && constraint.contype == ConstrType::Foreign {
+                                    for ColumnDefConstraint::Constraint(constraint) in
+                                        &column_def.constraints
+                                    {
+                                        if !constraint.skip_validation
+                                            && constraint.contype == ConstrType::Foreign
+                                        {
                                             errs.push(RuleViolation::new(
                                                 RuleViolationKind::AddingForeignKeyConstraint,
                                                 raw_stmt.into(),

--- a/linter/src/rules/adding_foreign_key_constraint.rs
+++ b/linter/src/rules/adding_foreign_key_constraint.rs
@@ -53,7 +53,7 @@ pub fn adding_foreign_key_constraint(
                                         ));
                                     }
                                 }
-                            } else if let AlterTableType::AddColumn = command.subtype {
+                            } else if AlterTableType::AddColumn == command.subtype {
                                 if let Some(AlterTableDef::ColumnDef(column_def)) = &command.def {
                                     for ColumnDefConstraint::Constraint(constraint) in
                                         &column_def.constraints


### PR DESCRIPTION
Noticed a case that squeaks by this check.  There are so many ways to add a constraint in SQL 😄 

```sql
ALTER TABLE "emails" ADD COLUMN "user_id" INT REFERENCES "user" ("id");
```