### PR TITLE
Fix flake version

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
           {
             squawk = final.rustPlatform.buildRustPackage {
               pname = "squawk";
-              version = "0.13.2";
+              version = "0.17.0";
 
               cargoLock = {
                 lockFile = ./Cargo.lock;

--- a/s/update-version
+++ b/s/update-version
@@ -8,9 +8,8 @@ function main {
     echo "updating version to '$NEW_VERSION'..."
     fastmod '^version = ".*"' 'version = "'$NEW_VERSION'"' cli/Cargo.toml
     fastmod '"version": ".*"' '"version": "'$NEW_VERSION'"' package.json
+    fastmod -m '(pname = "squawk";.*?)version = ".*?"' '${1}version = "'$NEW_VERSION'"' flake.nix
 }
 
 
 main $@
-
-


### PR DESCRIPTION
Hello! I noticed when using the flake that the Nix default package version didn't match what `squawk --version` showed. I found that the version was out of date in `flake.nix` so I updated that and the `s/update-version` script so that it should be kept in sync for the future.

Awesome project, by the way!