### PR TITLE
fix(linter): indexing error & bug with constraint_missing_not_valid

### DIFF
--- a/linter/src/rules/ban_char_field.rs
+++ b/linter/src/rules/ban_char_field.rs
@@ -73,4 +73,17 @@ COMMIT;
         "#;
         assert_debug_snapshot!(lint_sql(sql));
     }
+    #[test]
+    fn regression_with_indexing_2() {
+        let sql = r#"
+BEGIN;
+ALTER TABLE "core_recipe" ADD COLUMN "foo" integer DEFAULT 10;
+ALTER TABLE "core_recipe" ADD CONSTRAINT foo_not_null
+    CHECK ("foo" IS NOT NULL) NOT VALID;
+COMMIT;
+BEGIN;
+
+"#;
+        assert_debug_snapshot!(lint_sql(sql));
+    }
 }

--- a/linter/src/rules/constraint_missing_not_valid.rs
+++ b/linter/src/rules/constraint_missing_not_valid.rs
@@ -13,7 +13,6 @@ fn not_valid_validate_in_transaction(tree: &[RawStmt]) -> Vec<Span> {
     let mut not_valid_names = HashSet::new();
     let mut in_transaction = false;
     let mut in_bad_index = false;
-    let mut begin_span_start = 0;
     let mut bad_spans = vec![];
     for raw_stmt in tree {
         match &raw_stmt.stmt {
@@ -21,16 +20,11 @@ fn not_valid_validate_in_transaction(tree: &[RawStmt]) -> Vec<Span> {
                 if stmt.kind == TransactionStmtKind::Begin && !in_transaction {
                     in_transaction = true;
                     in_bad_index = false;
-                    begin_span_start = raw_stmt.stmt_location;
+                    not_valid_names.clear();
                 }
                 if stmt.kind == TransactionStmtKind::Commit {
                     if in_bad_index && in_transaction {
-                        bad_spans.push(Span {
-                            start: begin_span_start,
-                            len: Some(
-                                raw_stmt.stmt_location + raw_stmt.stmt_len.unwrap_or_default(),
-                            ),
-                        });
+                        bad_spans.push(raw_stmt.into());
                     }
                     in_transaction = false;
                 }

--- a/linter/src/rules/snapshots/squawk_linter__rules__ban_char_field__test_rules__regression_with_indexing_2.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__ban_char_field__test_rules__regression_with_indexing_2.snap
@@ -1,0 +1,5 @@
+---
+source: linter/src/rules/ban_char_field.rs
+expression: lint_sql(sql)
+---
+[]


### PR DESCRIPTION
- we weren't clearing the set of okay constraint names when we entered a new transaction
- also there was an issue where we were constructing a span that had a length greater than the actual SQL. Fiddling with this was annoying so I scraped it and now we pick the last statement for reporting.

rel: https://github.com/sbdchd/squawk/issues/258