### PR TITLE
Add rustfmt (cargo fmt) as a tool in the flake-provided dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
 
           nativeBuildInputs = old.nativeBuildInputs ++ (with pkgs; [
             cargo-insta
+            rustfmt
           ]);
         });
       });


### PR DESCRIPTION
This was missing when using `nix develop`, and since it is used by `s/fmt`, I figured it should be added to provide a (more) complete development environment.