### PR TITLE
Update Cargo.lock to relect version update in 9afce6a

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "atty",
  "base64 0.12.3",


### PR DESCRIPTION
I was noticing that Cargo.lock had unstaged changes in it when I built against a recent version of master. It looks like the version was bumped in 9afce6a for cli/Cargo.toml, but the lock file didn't get updated. I'm assuming this should be changed as well, but feel free to close if that's not the case.