### PR TITLE
Add Clippy as a tool in the flake-provided dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
 
           nativeBuildInputs = old.nativeBuildInputs ++ (with pkgs; [
             cargo-insta
+            clippy
             rustfmt
           ]);
         });


### PR DESCRIPTION
I noticed this was also missing when addressing comments in #264, and since it is used by `s/lint`, I figured it should be added to provide a (more) complete development environment.