### PR TITLE
Support TableLikeClause in table creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "atty",
  "base64 0.12.3",

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -771,6 +771,12 @@ pub struct Constraint {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+pub struct TableLikeClause {
+    pub relation: RangeVar,
+    pub options: i32,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
 pub struct RenameStmt {
     // Node	   *object;			/* in case it's some other object */
     pub newname: String,
@@ -790,6 +796,7 @@ pub struct RenameStmt {
 pub enum TableElt {
     ColumnDef(ColumnDef),
     Constraint(Constraint),
+    TableLikeClause(TableLikeClause),
 }
 
 /// What to do at commit time for temporary relations

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -179,6 +179,14 @@ COMMIT;
     }
 
     #[test]
+    fn test_parsing_create_table_using_like() {
+        let sql =
+            r#"CREATE TABLE core_bar (LIKE core_foo INCLUDING DEFAULTS INCLUDING CONSTRAINTS);"#;
+        let res = parse_sql_query(sql);
+        assert_debug_snapshot!(res);
+    }
+
+    #[test]
     fn test_parse_sql_create_index() {
         let sql = r#"CREATE INDEX "table_name_idx" ON "table_name" ("table_field");"#;
         let res = parse_sql_query(sql);

--- a/parser/src/snapshots/squawk_parser__parse__tests__parsing_create_table_using_like.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parsing_create_table_using_like.snap
@@ -1,0 +1,53 @@
+---
+source: parser/src/parse.rs
+expression: res
+
+---
+Ok(
+    [
+        RawStmt {
+            stmt: CreateStmt(
+                CreateStmt {
+                    relation: RangeVar {
+                        catalogname: None,
+                        schemaname: None,
+                        relname: "core_bar",
+                        inh: true,
+                        relpersistence: "p",
+                        alias: None,
+                        location: 13,
+                    },
+                    table_elts: [
+                        TableLikeClause(
+                            TableLikeClause {
+                                relation: RangeVar {
+                                    catalogname: None,
+                                    schemaname: None,
+                                    relname: "core_foo",
+                                    inh: true,
+                                    relpersistence: "p",
+                                    alias: None,
+                                    location: 28,
+                                },
+                                options: 6,
+                            },
+                        ),
+                    ],
+                    inh_relations: [],
+                    partbound: None,
+                    partspec: None,
+                    of_typename: None,
+                    constraints: [],
+                    options: [],
+                    oncommit: Noop,
+                    tablespacename: None,
+                    if_not_exists: false,
+                },
+            ),
+            stmt_location: 0,
+            stmt_len: Some(
+                78,
+            ),
+        },
+    ],
+)


### PR DESCRIPTION
Adds minimal support for `CREATE TABLE ... (LIKE ...)`, resolves #270 