### PR TITLE
Split prefer-big-int into int and smallint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.pending-snap
 *.tgz
 *.pem
+
+# IntelliJ IDE users
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "atty",
  "base64 0.12.3",

--- a/docs/docs/prefer-big-int.md
+++ b/docs/docs/prefer-big-int.md
@@ -3,49 +3,10 @@ id: prefer-big-int
 title: prefer-big-int
 ---
 
+## deprecated
 
-## problem
+This rule has been split into ["prefer-bigint-over-int"](./prefer-bigint-over-int.md) and ["prefer-bigint-over-smallint"](./prefer-bigint-over-smallint.md).
 
-Using 32 bit integer fields can result in hitting the max int limit.
+Please use those rules instead.
 
-## solution
-
-Use 64 bit integer field instead, like `BIGSERIAL` or `BIGINT`.
-
-
-### serial
-
-Instead of:
-
-```sql
-CREATE TABLE posts (
-  id serial primary key
-)
-```
-
-Use:
-
-```sql
-CREATE TABLE posts (
-  id bigserial primary key
-)
-```
-
-
-### int
-
-Instead of:
-
-```sql
-CREATE TABLE posts (
-  id int primary key
-)
-```
-
-Use:
-
-```sql
-CREATE TABLE posts (
-  id bigint primary key
-)
-```
+This will be removed in a future release.

--- a/docs/docs/prefer-big-int.md
+++ b/docs/docs/prefer-big-int.md
@@ -5,8 +5,8 @@ title: prefer-big-int
 
 ## deprecated
 
-This rule has been split into ["prefer-bigint-over-int"](./prefer-bigint-over-int.md) and ["prefer-bigint-over-smallint"](./prefer-bigint-over-smallint.md).
+:::caution Deprecated
+This rule has been deprecated in favor of ["prefer-bigint-over-int"](./prefer-bigint-over-int.md) and ["prefer-bigint-over-smallint"](./prefer-bigint-over-smallint.md).
+:::
 
-Please use those rules instead.
-
-This will be removed in a future release.
+This rule has been split into ["prefer-bigint-over-int"](./prefer-bigint-over-int.md) and ["prefer-bigint-over-smallint"](./prefer-bigint-over-smallint.md) to allow more granular linting against integer fields. Please use this new rules as this rule will be removed in a future release.

--- a/docs/docs/prefer-bigint-over-int.md
+++ b/docs/docs/prefer-bigint-over-int.md
@@ -1,0 +1,55 @@
+---
+id: prefer-bigint-over-int
+title: prefer-bigint-over-int
+---
+
+
+## problem
+
+Using 32 bit integer fields can result in hitting the max int limit.
+
+## solution
+
+Use 64 bit integer field instead, like `BIGSERIAL` or `BIGINT`.
+
+
+### serial
+
+Instead of:
+
+```sql
+CREATE TABLE posts (
+  id serial primary key
+)
+```
+
+Use:
+
+```sql
+CREATE TABLE posts (
+  id bigserial primary key
+)
+```
+
+
+### int
+
+Instead of:
+
+```sql
+CREATE TABLE posts (
+  id int primary key
+)
+```
+
+Use:
+
+```sql
+CREATE TABLE posts (
+  id bigint primary key
+)
+```
+
+## related
+
+See ["prefer-bigint-over-smallint"](./prefer-bigint-over-smallint.md).

--- a/docs/docs/prefer-bigint-over-int.md
+++ b/docs/docs/prefer-bigint-over-int.md
@@ -52,4 +52,4 @@ CREATE TABLE posts (
 
 ## related
 
-See ["prefer-bigint-over-smallint"](./prefer-bigint-over-smallint.md).
+See ["prefer-bigint-over-smallint"](./prefer-bigint-over-smallint.md)for a simliar lint rule against 16 bit integers.

--- a/docs/docs/prefer-bigint-over-smallint.md
+++ b/docs/docs/prefer-bigint-over-smallint.md
@@ -1,0 +1,55 @@
+---
+id: prefer-bigint-over-smallint
+title: prefer-bigint-over-smallint
+---
+
+
+## problem
+
+Using 16 bit integer fields can result in hitting the max int limit.
+
+## solution
+
+Use 64 bit integer field instead, like `BIGSERIAL` or `BIGINT`.
+
+
+### smallserial
+
+Instead of:
+
+```sql
+CREATE TABLE posts (
+  id smallserial primary key
+)
+```
+
+Use:
+
+```sql
+CREATE TABLE posts (
+  id bigserial primary key
+)
+```
+
+
+### smallint
+
+Instead of:
+
+```sql
+CREATE TABLE posts (
+  id smallint primary key
+)
+```
+
+Use:
+
+```sql
+CREATE TABLE posts (
+  id bigint primary key
+)
+```
+
+## related
+
+See ["prefer-bigint-over-int"](./prefer-bigint-over-int.md).

--- a/docs/docs/prefer-bigint-over-smallint.md
+++ b/docs/docs/prefer-bigint-over-smallint.md
@@ -52,4 +52,4 @@ CREATE TABLE posts (
 
 ## related
 
-See ["prefer-bigint-over-int"](./prefer-bigint-over-int.md).
+See ["prefer-bigint-over-int"](./prefer-bigint-over-int.md) for a simliar lint rule against 32 bit integers.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -13,6 +13,8 @@ module.exports = {
       "constraint-missing-not-valid",
       "disallowed-unique-constraint",
       "prefer-big-int",
+      "prefer-bigint-over-int",
+      "prefer-bigint-over-smallint",
       "prefer-identity",
       "prefer-robust-stmts",
       "prefer-text-field",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -102,7 +102,17 @@ const rules = [
   {
     name: "prefer-big-int",
     tags: ["schema"],
+    description: "Deprecated. See prefer-bigint-over-int and prefer-bigint-over-smallint instead.",
+  },
+  {
+    name: "prefer-bigint-over-int",
+    tags: ["schema"],
     description: "Prevent hitting the 32 bit max int limit.",
+  },
+  {
+    name: "prefer-bigint-over-smallint",
+    tags: ["schema"],
+    description: "Prevent hitting the 16 bit max int limit.",
   },
   {
     name: "prefer-identity",

--- a/linter/src/lib.rs
+++ b/linter/src/lib.rs
@@ -14,8 +14,9 @@ use crate::rules::{
     adding_field_with_default, adding_foreign_key_constraint, adding_not_nullable_field,
     adding_primary_key_constraint, ban_char_type, ban_drop_column, ban_drop_database,
     changing_column_type, constraint_missing_not_valid, disallow_unique_constraint,
-    prefer_robust_stmts, prefer_text_field, prefer_timestamptz, renaming_column, renaming_table,
-    require_concurrent_index_creation, require_concurrent_index_deletion,
+    prefer_bigint_over_int, prefer_bigint_over_smallint, prefer_robust_stmts, prefer_text_field,
+    prefer_timestamptz, renaming_column, renaming_table, require_concurrent_index_creation,
+    require_concurrent_index_deletion,
 };
 use crate::violations::{RuleViolation, RuleViolationKind, ViolationMessage};
 use squawk_parser::ast::RawStmt;
@@ -180,6 +181,30 @@ lazy_static! {
         messages: vec![
             ViolationMessage::Note(
                 "Hitting the max 32 bit integer is possible and may break your application.".into()
+            ),
+            ViolationMessage::Help(
+                "Use 64bit integer values instead to prevent hitting this limit.".into()
+            ),
+        ],
+    },
+    SquawkRule {
+        name: RuleViolationKind::PreferBigintOverInt,
+        func: prefer_bigint_over_int,
+        messages: vec![
+            ViolationMessage::Note(
+                "Hitting the max 32 bit integer is possible and may break your application.".into()
+            ),
+            ViolationMessage::Help(
+                "Use 64bit integer values instead to prevent hitting this limit.".into()
+            ),
+        ],
+    },
+    SquawkRule {
+        name: RuleViolationKind::PreferBigintOverSmallint,
+        func: prefer_bigint_over_smallint,
+        messages: vec![
+            ViolationMessage::Note(
+                "Hitting the max 16 bit integer is possible and may break your application.".into()
             ),
             ViolationMessage::Help(
                 "Use 64bit integer values instead to prevent hitting this limit.".into()

--- a/linter/src/rules/mod.rs
+++ b/linter/src/rules/mod.rs
@@ -38,3 +38,7 @@ pub mod prefer_identity;
 pub use prefer_identity::*;
 pub mod prefer_big_int;
 pub use prefer_big_int::*;
+pub mod prefer_bigint_over_int;
+pub use prefer_bigint_over_int::*;
+pub mod prefer_bigint_over_smallint;
+pub use prefer_bigint_over_smallint::*;

--- a/linter/src/rules/prefer_bigint_over_int.rs
+++ b/linter/src/rules/prefer_bigint_over_int.rs
@@ -1,0 +1,121 @@
+use std::collections::HashSet;
+
+use crate::{
+    versions::Version,
+    violations::{RuleViolation, RuleViolationKind},
+};
+
+use squawk_parser::ast::{ColumnDef, RawStmt};
+
+use super::utils::columns_create_or_modified;
+
+#[must_use]
+pub fn prefer_bigint_over_int(
+    tree: &[RawStmt],
+    _pg_version: Option<Version>,
+    _assume_in_transaction: bool,
+) -> Vec<RuleViolation> {
+    let mut errs = vec![];
+    for raw_stmt in tree {
+        for column in columns_create_or_modified(&raw_stmt.stmt) {
+            check_column_def(&mut errs, raw_stmt, column);
+        }
+    }
+    errs
+}
+
+lazy_static! {
+    static ref INT_TYPES: HashSet<&'static str> =
+        HashSet::from(["integer", "int4", "serial", "serial4",]);
+}
+
+fn check_column_def(errs: &mut Vec<RuleViolation>, raw_stmt: &RawStmt, column_def: &ColumnDef) {
+    if let Some(column_name) = column_def.type_name.names.last() {
+        if INT_TYPES.contains(column_name.string.str.as_str()) {
+            errs.push(RuleViolation::new(
+                RuleViolationKind::PreferBigintOverInt,
+                raw_stmt.into(),
+                None,
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_rules {
+    use insta::assert_debug_snapshot;
+
+    use crate::{
+        check_sql_with_rule,
+        rules::test_utils::violations_to_kinds,
+        violations::{RuleViolation, RuleViolationKind},
+    };
+
+    fn lint_sql(sql: &str) -> Vec<RuleViolation> {
+        check_sql_with_rule(sql, &RuleViolationKind::PreferBigintOverInt, None, false).unwrap()
+    }
+
+    #[test]
+    fn test_create_table_ok() {
+        let ok_sql = r#"
+create table users (
+    id bigint
+);
+create table users (
+    id int8
+);
+create table users (
+    id bigserial
+);
+create table users (
+    id serial8
+);
+create table users (
+    id smallint
+);
+create table users (
+    id int2
+);
+create table users (
+    id smallserial
+);
+create table users (
+    id serial2
+);
+  "#;
+        assert_eq!(lint_sql(ok_sql), vec![]);
+    }
+    #[test]
+    fn test_create_table_bad() {
+        let bad_sql = r#"
+create table users (
+    id integer
+);
+create table users (
+    id int4
+);
+create table users (
+    id serial
+);
+create table users (
+    id serial4
+);
+  "#;
+        let res = lint_sql(bad_sql);
+        let violations = violations_to_kinds(&res);
+        assert_eq!(
+            violations.len(),
+            4,
+            "we should have 4 statements with violations"
+        );
+        assert_eq!(
+            violations.len(),
+            violations
+                .into_iter()
+                .filter(|v| { *v == RuleViolationKind::PreferBigintOverInt })
+                .count(),
+            "all violations should be big int violations"
+        );
+        assert_debug_snapshot!(res);
+    }
+}

--- a/linter/src/rules/prefer_bigint_over_smallint.rs
+++ b/linter/src/rules/prefer_bigint_over_smallint.rs
@@ -1,0 +1,127 @@
+use std::collections::HashSet;
+
+use crate::{
+    versions::Version,
+    violations::{RuleViolation, RuleViolationKind},
+};
+
+use squawk_parser::ast::{ColumnDef, RawStmt};
+
+use super::utils::columns_create_or_modified;
+
+#[must_use]
+pub fn prefer_bigint_over_smallint(
+    tree: &[RawStmt],
+    _pg_version: Option<Version>,
+    _assume_in_transaction: bool,
+) -> Vec<RuleViolation> {
+    let mut errs = vec![];
+    for raw_stmt in tree {
+        for column in columns_create_or_modified(&raw_stmt.stmt) {
+            check_column_def(&mut errs, raw_stmt, column);
+        }
+    }
+    errs
+}
+
+lazy_static! {
+    static ref SMALL_INT_TYPES: HashSet<&'static str> =
+        HashSet::from(["smallint", "int2", "smallserial", "serial2",]);
+}
+
+fn check_column_def(errs: &mut Vec<RuleViolation>, raw_stmt: &RawStmt, column_def: &ColumnDef) {
+    if let Some(column_name) = column_def.type_name.names.last() {
+        if SMALL_INT_TYPES.contains(column_name.string.str.as_str()) {
+            errs.push(RuleViolation::new(
+                RuleViolationKind::PreferBigintOverSmallint,
+                raw_stmt.into(),
+                None,
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod test_rules {
+    use insta::assert_debug_snapshot;
+
+    use crate::{
+        check_sql_with_rule,
+        rules::test_utils::violations_to_kinds,
+        violations::{RuleViolation, RuleViolationKind},
+    };
+
+    fn lint_sql(sql: &str) -> Vec<RuleViolation> {
+        check_sql_with_rule(
+            sql,
+            &RuleViolationKind::PreferBigintOverSmallint,
+            None,
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_create_table_ok() {
+        let ok_sql = r#"
+create table users (
+    id bigint
+);
+create table users (
+    id int8
+);
+create table users (
+    id bigserial
+);
+create table users (
+    id serial8
+);
+create table users (
+    id integer
+);
+create table users (
+    id int4
+);
+create table users (
+    id serial
+);
+create table users (
+    id serial4
+);
+  "#;
+        assert_eq!(lint_sql(ok_sql), vec![]);
+    }
+    #[test]
+    fn test_create_table_bad() {
+        let bad_sql = r#"
+create table users (
+    id smallint
+);
+create table users (
+    id int2
+);
+create table users (
+    id smallserial
+);
+create table users (
+    id serial2
+);
+  "#;
+        let res = lint_sql(bad_sql);
+        let violations = violations_to_kinds(&res);
+        assert_eq!(
+            violations.len(),
+            4,
+            "we should have 4 statements with violations"
+        );
+        assert_eq!(
+            violations.len(),
+            violations
+                .into_iter()
+                .filter(|v| { *v == RuleViolationKind::PreferBigintOverSmallint })
+                .count(),
+            "all violations should be big int violations"
+        );
+        assert_debug_snapshot!(res);
+    }
+}

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_bigint_over_int__test_rules__create_table_bad.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_bigint_over_int__test_rules__create_table_bad.snap
@@ -1,0 +1,75 @@
+---
+source: linter/src/rules/prefer_bigint_over_int.rs
+expression: res
+
+---
+[
+    RuleViolation {
+        kind: PreferBigintOverInt,
+        span: Span {
+            start: 0,
+            len: Some(
+                38,
+            ),
+        },
+        messages: [
+            Note(
+                "Hitting the max 32 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+    RuleViolation {
+        kind: PreferBigintOverInt,
+        span: Span {
+            start: 39,
+            len: Some(
+                35,
+            ),
+        },
+        messages: [
+            Note(
+                "Hitting the max 32 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+    RuleViolation {
+        kind: PreferBigintOverInt,
+        span: Span {
+            start: 75,
+            len: Some(
+                37,
+            ),
+        },
+        messages: [
+            Note(
+                "Hitting the max 32 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+    RuleViolation {
+        kind: PreferBigintOverInt,
+        span: Span {
+            start: 113,
+            len: Some(
+                38,
+            ),
+        },
+        messages: [
+            Note(
+                "Hitting the max 32 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+]

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_bigint_over_smallint__test_rules__create_table_bad.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_bigint_over_smallint__test_rules__create_table_bad.snap
@@ -1,0 +1,75 @@
+---
+source: linter/src/rules/prefer_bigint_over_smallint.rs
+expression: res
+
+---
+[
+    RuleViolation {
+        kind: PreferBigintOverSmallint,
+        span: Span {
+            start: 0,
+            len: Some(
+                39,
+            ),
+        },
+        messages: [
+            Note(
+                "Hitting the max 16 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+    RuleViolation {
+        kind: PreferBigintOverSmallint,
+        span: Span {
+            start: 40,
+            len: Some(
+                35,
+            ),
+        },
+        messages: [
+            Note(
+                "Hitting the max 16 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+    RuleViolation {
+        kind: PreferBigintOverSmallint,
+        span: Span {
+            start: 76,
+            len: Some(
+                42,
+            ),
+        },
+        messages: [
+            Note(
+                "Hitting the max 16 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+    RuleViolation {
+        kind: PreferBigintOverSmallint,
+        span: Span {
+            start: 119,
+            len: Some(
+                38,
+            ),
+        },
+        messages: [
+            Note(
+                "Hitting the max 16 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+]

--- a/linter/src/snapshots/squawk_linter__test_rules__rule_names_debug_snap.snap
+++ b/linter/src/snapshots/squawk_linter__test_rules__rule_names_debug_snap.snap
@@ -1,6 +1,7 @@
 ---
 source: linter/src/lib.rs
 expression: rule_names
+
 ---
 [
     "adding-field-with-default",
@@ -14,6 +15,8 @@ expression: rule_names
     "constraint-missing-not-valid",
     "disallowed-unique-constraint",
     "prefer-big-int",
+    "prefer-bigint-over-int",
+    "prefer-bigint-over-smallint",
     "prefer-identity",
     "prefer-robust-stmts",
     "prefer-text-field",

--- a/linter/src/snapshots/squawk_linter__test_rules__rule_names_display_snap.snap
+++ b/linter/src/snapshots/squawk_linter__test_rules__rule_names_display_snap.snap
@@ -1,6 +1,7 @@
 ---
 source: linter/src/lib.rs
 expression: "rule_names.join(\"\\n\")"
+
 ---
 adding-field-with-default
 adding-foreign-key-constraint
@@ -13,6 +14,8 @@ changing-column-type
 constraint-missing-not-valid
 disallowed-unique-constraint
 prefer-big-int
+prefer-bigint-over-int
+prefer-bigint-over-smallint
 prefer-identity
 prefer-robust-stmts
 prefer-text-field

--- a/linter/src/violations.rs
+++ b/linter/src/violations.rs
@@ -35,6 +35,10 @@ pub enum RuleViolationKind {
     InvalidStatement,
     #[serde(rename = "prefer-big-int")]
     PreferBigInt,
+    #[serde(rename = "prefer-bigint-over-int")]
+    PreferBigintOverInt,
+    #[serde(rename = "prefer-bigint-over-smallint")]
+    PreferBigintOverSmallint,
     #[serde(rename = "prefer-identity")]
     PreferIdentity,
     #[serde(rename = "prefer-robust-stmts")]


### PR DESCRIPTION
## Context
Fixes #272

## Implementation
- mostly copy/paste to ensure `prefer-big-int` stays backwards compatible and easy to delete in a future release
