### PR TITLE
Support PartitionCmd in alter table statement

### DIFF
--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -663,6 +663,7 @@ pub enum AlterTableDef {
     Constant(Value),
     ReplicaIdentityStmt(Value),
     SQLValueFunction(Value),
+    PartitionCmd(Value),
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -1304,6 +1304,27 @@ CREATE TABLE measurement_y2006m02 PARTITION OF measurement
         let res = parse_sql_query(sql);
         assert_debug_snapshot!(res);
     }
+
+    #[test]
+    fn test_parse_attach_table_partition() {
+        let sql = r#"
+ALTER TABLE measurement ATTACH PARTITION measurement_y2008m02
+    FOR VALUES FROM ('2008-02-01') TO ('2008-03-01' );
+"#;
+        let res = parse_sql_query(sql);
+        assert_debug_snapshot!(res);
+    }
+
+    #[test]
+    fn test_parse_detach_table_partition() {
+        let sql = r#"
+ALTER TABLE measurement
+    DETACH PARTITION measurement_y2006m02;
+"#;
+        let res = parse_sql_query(sql);
+        assert_debug_snapshot!(res);
+    }
+
     #[test]
     fn test_drop_index() {
         let sql = r#"

--- a/parser/src/snapshots/squawk_parser__parse__tests__parse_attach_table_partition.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parse_attach_table_partition.snap
@@ -1,0 +1,100 @@
+---
+source: parser/src/parse.rs
+expression: res
+
+---
+Ok(
+    [
+        RawStmt {
+            stmt: AlterTableStmt(
+                AlterTableStmt {
+                    cmds: [
+                        AlterTableCmd(
+                            AlterTableCmd {
+                                subtype: AttachPartition,
+                                name: None,
+                                def: Some(
+                                    PartitionCmd(
+                                        Object({
+                                            "bound": Object({
+                                                "location": Number(
+                                                    78,
+                                                ),
+                                                "lowerdatums": Array([
+                                                    Object({
+                                                        "A_Const": Object({
+                                                            "location": Number(
+                                                                84,
+                                                            ),
+                                                            "val": Object({
+                                                                "String": Object({
+                                                                    "str": String(
+                                                                        "2008-02-01",
+                                                                    ),
+                                                                }),
+                                                            }),
+                                                        }),
+                                                    }),
+                                                ]),
+                                                "strategy": String(
+                                                    "r",
+                                                ),
+                                                "upperdatums": Array([
+                                                    Object({
+                                                        "A_Const": Object({
+                                                            "location": Number(
+                                                                102,
+                                                            ),
+                                                            "val": Object({
+                                                                "String": Object({
+                                                                    "str": String(
+                                                                        "2008-03-01",
+                                                                    ),
+                                                                }),
+                                                            }),
+                                                        }),
+                                                    }),
+                                                ]),
+                                            }),
+                                            "name": Object({
+                                                "inh": Bool(
+                                                    true,
+                                                ),
+                                                "location": Number(
+                                                    42,
+                                                ),
+                                                "relname": String(
+                                                    "measurement_y2008m02",
+                                                ),
+                                                "relpersistence": String(
+                                                    "p",
+                                                ),
+                                            }),
+                                        }),
+                                    ),
+                                ),
+                                behavior: Restrict,
+                                missing_ok: false,
+                            },
+                        ),
+                    ],
+                    relation: RangeVar {
+                        catalogname: None,
+                        schemaname: None,
+                        relname: "measurement",
+                        inh: true,
+                        relpersistence: "p",
+                        alias: None,
+                        location: 13,
+                    },
+                    relkind: Table,
+                    missing_ok: false,
+                },
+            ),
+            stmt_location: 0,
+            stmt_len: Some(
+                116,
+            ),
+        },
+    ],
+)

--- a/parser/src/snapshots/squawk_parser__parse__tests__parse_detach_table_partition.snap
+++ b/parser/src/snapshots/squawk_parser__parse__tests__parse_detach_table_partition.snap
@@ -1,0 +1,60 @@
+---
+source: parser/src/parse.rs
+expression: res
+
+---
+Ok(
+    [
+        RawStmt {
+            stmt: AlterTableStmt(
+                AlterTableStmt {
+                    cmds: [
+                        AlterTableCmd(
+                            AlterTableCmd {
+                                subtype: DetachPartition,
+                                name: None,
+                                def: Some(
+                                    PartitionCmd(
+                                        Object({
+                                            "name": Object({
+                                                "inh": Bool(
+                                                    true,
+                                                ),
+                                                "location": Number(
+                                                    46,
+                                                ),
+                                                "relname": String(
+                                                    "measurement_y2006m02",
+                                                ),
+                                                "relpersistence": String(
+                                                    "p",
+                                                ),
+                                            }),
+                                        }),
+                                    ),
+                                ),
+                                behavior: Restrict,
+                                missing_ok: false,
+                            },
+                        ),
+                    ],
+                    relation: RangeVar {
+                        catalogname: None,
+                        schemaname: None,
+                        relname: "measurement",
+                        inh: true,
+                        relpersistence: "p",
+                        alias: None,
+                        location: 13,
+                    },
+                    relkind: Table,
+                    missing_ok: false,
+                },
+            ),
+            stmt_location: 0,
+            stmt_len: Some(
+                66,
+            ),
+        },
+    ],
+)


### PR DESCRIPTION
Adds minimal support for partition commands, partially resolves #279 