### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "atty",
  "base64 0.12.3",

--- a/s/update-version
+++ b/s/update-version
@@ -7,6 +7,7 @@ function main {
     NEW_VERSION="$1"
     echo "updating version to '$NEW_VERSION'..."
     fastmod '^version = ".*"' 'version = "'$NEW_VERSION'"' cli/Cargo.toml
+    fastmod -m '(name = "squawk"\n)version = ".*?"' '${1}version = "'$NEW_VERSION'"' Cargo.lock
     fastmod '"version": ".*"' '"version": "'$NEW_VERSION'"' package.json
     fastmod -m '(pname = "squawk";.*?)version = ".*?"' '${1}version = "'$NEW_VERSION'"' flake.nix
 }


### PR DESCRIPTION
Sorry for another one of these (#266). I added another replacement to `s/update-version` to try to prevent this from happening in the future. However, I totally understand if you would like to enforce this check elsewhere since Cargo.lock is a generated file.