### PR TITLE
Fix c_char type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,7 +1595,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "atty",
  "base64 0.12.3",

--- a/parser/src/parse.rs
+++ b/parser/src/parse.rs
@@ -4,8 +4,9 @@ use libpg_query::{pg_query_free_parse_result, pg_query_parse};
 use serde::Deserialize;
 use serde_json::Value;
 use std::ffi::{CStr, CString};
+use std::os::raw::c_char;
 
-fn parse_str_or_none(str_ptr: *mut i8) -> Option<String> {
+fn parse_str_or_none(str_ptr: *mut c_char) -> Option<String> {
     if str_ptr.is_null() {
         None
     } else {


### PR DESCRIPTION
`libpg_query::PgQueryError::message` [is declared](https://docs.rs/libpg_query-sys/0.2.1/libpg_query/struct.PgQueryError.html) as `c_char`, not `i8`. This causes error when building `squawk` on platforms where `c_char` is `u8`:

```
   Compiling squawk-parser v0.0.0 (/src/origin/parser)
error[E0308]: mismatched types======>  ] 280/292: openssl-sys(build), squawk-parser
  --> parser/src/parse.rs:12:38
   |
12 |         unsafe { Some(CStr::from_ptr(str_ptr).to_string_lossy().into()) }
   |                       -------------- ^^^^^^^ expected `u8`, found `i8`
   |                       |
   |                       arguments to this function are incorrect
   |
   = note: expected raw pointer `*const u8`
              found raw pointer `*mut i8`
note: associated function defined here
  --> /rustc/fc594f15669680fa70d255faec3ca3fb507c3405/library/core/src/ffi/c_str.rs:256:25


error[E0308]: mismatched types======>  ] 280/292: openssl-sys(build), squawk-parser
  --> parser/src/parse.rs:26:69
   |
26 |             return Err(PgQueryError::PgParseError(parse_str_or_none(err.message)));
   |                                                   ----------------- ^^^^^^^^^^^ expected `i8`, found `u8`
   |                                                   |
   |                                                   arguments to this function are incorrect
   |
   = note: expected raw pointer `*mut i8`
              found raw pointer `*mut u8`
note: function defined here
  --> parser/src/parse.rs:8:4
   |
8  | fn parse_str_or_none(str_ptr: *mut i8) -> Option<String> {
   |    ^^^^^^^^^^^^^^^^^ ----------------


error: aborting due to 2 previous errors 280/292: openssl-sys(build), squawk-parser


For more information about this error, try `rustc --explain E0308`.

error: could not compile `squawk-parser` due to 3 previous errors
```