### PR TITLE
Introduce a new rule that bans dropping NOT NULL constraints

### DIFF
--- a/docs/docs/ban-drop-not-null.md
+++ b/docs/docs/ban-drop-not-null.md
@@ -1,0 +1,14 @@
+---
+id: ban-drop-not-null
+title: ban-drop-not-null
+---
+
+## problem
+
+Dropping a NOT NULL constraint may break existing clients.
+
+Application code or code written in procedural languages like PL/SQL or PL/pgSQL may not expect NULL values for the column that was previously guaranteed to be NOT NULL and therefore may fail to process them correctly.
+
+## solution
+
+Consider using a marker value that represents a "null" value and using that throughout application code. If NULL is truly desired, consider creating a new table similiar to the current one but that doesn't have the NOT NULL constraint, copy data to that, and create a view to replace the old table that either filters out NULL values or substitutes an appropriate marker value.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -9,6 +9,7 @@ module.exports = {
       "adding-serial-primary-key-field",
       "ban-char-field",
       "ban-drop-database",
+      "ban-drop-not-null",
       "changing-column-type",
       "constraint-missing-not-valid",
       "disallowed-unique-constraint",

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -84,6 +84,11 @@ const rules = [
       "Prevent breaking existing clients that depend on the database.",
   },
   {
+    name: "ban-drop-not-null",
+    tags: ["backwards compatibility"],
+    description: "Prevent breaking existing clients that don't expect NULL values.",
+  },
+  {
     name: "ban-drop-table",
     tags: ["backwards compatibility"],
     description:
@@ -245,4 +250,3 @@ function Home() {
 }
 
 export default Home
-

--- a/linter/src/lib.rs
+++ b/linter/src/lib.rs
@@ -8,6 +8,7 @@ pub mod violations;
 extern crate lazy_static;
 
 use crate::errors::CheckSqlError;
+use crate::rules::ban_drop_not_null;
 use crate::rules::prefer_big_int;
 use crate::rules::prefer_identity;
 use crate::rules::{
@@ -107,6 +108,15 @@ lazy_static! {
             ViolationMessage::Note(
                 "Dropping a database may break existing clients.".into()
             )
+        ],
+    },
+    SquawkRule {
+        name: RuleViolationKind::BanDropNotNull,
+        func: ban_drop_not_null,
+        messages: vec![
+            ViolationMessage::Note(
+                "Dropping a NOT NULL constraint may break existing clients.".into()
+            ),
         ],
     },
     SquawkRule {

--- a/linter/src/rules/ban_drop_not_null.rs
+++ b/linter/src/rules/ban_drop_not_null.rs
@@ -1,0 +1,51 @@
+use crate::{versions::Version, violations::RuleViolation, violations::RuleViolationKind};
+
+use squawk_parser::ast::{AlterTableCmds, AlterTableType, RawStmt, Stmt};
+
+#[must_use]
+pub fn ban_drop_not_null(
+    tree: &[RawStmt],
+    _pg_version: Option<Version>,
+    _assume_in_transaction: bool,
+) -> Vec<RuleViolation> {
+    let mut errs = vec![];
+    for raw_stmt in tree {
+        match &raw_stmt.stmt {
+            Stmt::AlterTableStmt(stmt) => {
+                for cmd in &stmt.cmds {
+                    let AlterTableCmds::AlterTableCmd(cmd) = cmd;
+                    if cmd.subtype == AlterTableType::DropNotNull {
+                        errs.push(RuleViolation::new(
+                            RuleViolationKind::BanDropNotNull,
+                            raw_stmt.into(),
+                            None,
+                        ));
+                    }
+                }
+            }
+            _ => continue,
+        }
+    }
+    errs
+}
+
+#[cfg(test)]
+mod test_rules {
+    use crate::{
+        check_sql_with_rule,
+        violations::{RuleViolation, RuleViolationKind},
+    };
+    use insta::assert_debug_snapshot;
+
+    fn lint_sql(sql: &str) -> Vec<RuleViolation> {
+        check_sql_with_rule(sql, &RuleViolationKind::BanDropNotNull, None, false).unwrap()
+    }
+
+    #[test]
+    fn test_ban_drop_not_null() {
+        let bad_sql = r#"
+ALTER TABLE "bar_tbl" ALTER COLUMN "foo_col" DROP NOT NULL;
+  "#;
+        assert_debug_snapshot!(lint_sql(bad_sql));
+    }
+}

--- a/linter/src/rules/mod.rs
+++ b/linter/src/rules/mod.rs
@@ -44,3 +44,5 @@ pub mod prefer_bigint_over_smallint;
 pub use prefer_bigint_over_smallint::*;
 pub mod ban_drop_table;
 pub use ban_drop_table::*;
+pub mod ban_drop_not_null;
+pub use ban_drop_not_null::*;

--- a/linter/src/rules/snapshots/squawk_linter__rules__ban_drop_not_null__test_rules__ban_drop_not_null.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__ban_drop_not_null__test_rules__ban_drop_not_null.snap
@@ -1,0 +1,20 @@
+---
+source: linter/src/rules/ban_drop_not_null.rs
+expression: lint_sql(bad_sql)
+---
+[
+    RuleViolation {
+        kind: BanDropNotNull,
+        span: Span {
+            start: 0,
+            len: Some(
+                59,
+            ),
+        },
+        messages: [
+            Note(
+                "Dropping a NOT NULL constraint may break existing clients.",
+            ),
+        ],
+    },
+]

--- a/linter/src/snapshots/squawk_linter__test_rules__rule_names_debug_snap.snap
+++ b/linter/src/snapshots/squawk_linter__test_rules__rule_names_debug_snap.snap
@@ -1,7 +1,6 @@
 ---
 source: linter/src/lib.rs
 expression: rule_names
-
 ---
 [
     "adding-field-with-default",
@@ -11,6 +10,7 @@ expression: rule_names
     "ban-char-field",
     "ban-drop-column",
     "ban-drop-database",
+    "ban-drop-not-null",
     "ban-drop-table",
     "changing-column-type",
     "constraint-missing-not-valid",

--- a/linter/src/snapshots/squawk_linter__test_rules__rule_names_display_snap.snap
+++ b/linter/src/snapshots/squawk_linter__test_rules__rule_names_display_snap.snap
@@ -1,7 +1,6 @@
 ---
 source: linter/src/lib.rs
 expression: "rule_names.join(\"\\n\")"
-
 ---
 adding-field-with-default
 adding-foreign-key-constraint
@@ -10,6 +9,7 @@ adding-serial-primary-key-field
 ban-char-field
 ban-drop-column
 ban-drop-database
+ban-drop-not-null
 ban-drop-table
 changing-column-type
 constraint-missing-not-valid

--- a/linter/src/violations.rs
+++ b/linter/src/violations.rs
@@ -53,6 +53,8 @@ pub enum RuleViolationKind {
     BanDropColumn,
     #[serde(rename = "ban-drop-table")]
     BanDropTable,
+    #[serde(rename = "ban-drop-not-null")]
+    BanDropNotNull,
     // generator::new-rule-above
 }
 


### PR DESCRIPTION
This addresses #282 by creating a new rule that bans dropping NOT NULL constraints on columns. This can cause problems in application code that doesn't expect NULL values.