### PR TITLE
Don't warn about foreign keys causing table scan when creating table in same transaction

### DIFF
--- a/linter/src/rules/adding_foreign_key_constraint.rs
+++ b/linter/src/rules/adding_foreign_key_constraint.rs
@@ -73,6 +73,7 @@ mod test_rules {
         check_sql_with_rule,
         violations::{RuleViolation, RuleViolationKind},
     };
+    use insta::assert_debug_snapshot;
 
     fn lint_sql(sql: &str) -> Vec<RuleViolation> {
         check_sql_with_rule(
@@ -100,9 +101,9 @@ CREATE TABLE email (
 COMMIT;
         "#;
 
-        let violations = lint_sql(sql);
-        assert_eq!(violations.len(), 0);
+        assert_debug_snapshot!(lint_sql(sql));
     }
+
     #[test]
     fn test_add_foreign_key_constraint_not_valid_validate() {
         let sql = r#"
@@ -113,9 +114,9 @@ ALTER TABLE "email" VALIDATE CONSTRAINT "fk_user";
 COMMIT;
         "#;
 
-        let violations = lint_sql(sql);
-        assert_eq!(violations.len(), 0);
+        assert_debug_snapshot!(lint_sql(sql));
     }
+
     #[test]
     fn test_add_foreign_key_constraint_lock() {
         let sql = r#"
@@ -125,13 +126,9 @@ ALTER TABLE "email" ADD CONSTRAINT "fk_user" FOREIGN KEY ("user_id") REFERENCES 
 COMMIT;
         "#;
 
-        let violations = lint_sql(sql);
-        assert_eq!(violations.len(), 1);
-        assert_eq!(
-            violations[0].kind,
-            RuleViolationKind::AddingForeignKeyConstraint
-        );
+        assert_debug_snapshot!(lint_sql(sql));
     }
+
     #[test]
     fn test_add_column_references_lock() {
         let sql = r#"
@@ -140,11 +137,6 @@ ALTER TABLE "emails" ADD COLUMN "user_id" INT REFERENCES "user" ("id");
 COMMIT;
         "#;
 
-        let violations = lint_sql(sql);
-        assert_eq!(violations.len(), 1);
-        assert_eq!(
-            violations[0].kind,
-            RuleViolationKind::AddingForeignKeyConstraint
-        );
+        assert_debug_snapshot!(lint_sql(sql));
     }
 }

--- a/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__add_column_references_lock.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__add_column_references_lock.snap
@@ -1,0 +1,23 @@
+---
+source: linter/src/rules/adding_foreign_key_constraint.rs
+expression: lint_sql(sql)
+---
+[
+    RuleViolation {
+        kind: AddingForeignKeyConstraint,
+        span: Span {
+            start: 7,
+            len: Some(
+                71,
+            ),
+        },
+        messages: [
+            Note(
+                "Requires a table scan of the table you're altering and a SHARE ROW EXCLUSIVE lock on both tables, which blocks writes to both tables while your table is scanned.",
+            ),
+            Help(
+                "Add NOT VALID to the constraint in one transaction and then VALIDATE the constraint in a separate transaction.",
+            ),
+        ],
+    },
+]

--- a/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__add_foreign_key_constraint_lock.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__add_foreign_key_constraint_lock.snap
@@ -1,0 +1,23 @@
+---
+source: linter/src/rules/adding_foreign_key_constraint.rs
+expression: lint_sql(sql)
+---
+[
+    RuleViolation {
+        kind: AddingForeignKeyConstraint,
+        span: Span {
+            start: 53,
+            len: Some(
+                94,
+            ),
+        },
+        messages: [
+            Note(
+                "Requires a table scan of the table you're altering and a SHARE ROW EXCLUSIVE lock on both tables, which blocks writes to both tables while your table is scanned.",
+            ),
+            Help(
+                "Add NOT VALID to the constraint in one transaction and then VALIDATE the constraint in a separate transaction.",
+            ),
+        ],
+    },
+]

--- a/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__add_foreign_key_constraint_not_valid_validate.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__add_foreign_key_constraint_not_valid_validate.snap
@@ -1,0 +1,5 @@
+---
+source: linter/src/rules/adding_foreign_key_constraint.rs
+expression: lint_sql(sql)
+---
+[]

--- a/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__create_table_and_add_foreign_key_constraint.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__create_table_and_add_foreign_key_constraint.snap
@@ -1,0 +1,5 @@
+---
+source: linter/src/rules/adding_foreign_key_constraint.rs
+expression: lint_sql(sql)
+---
+[]

--- a/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__create_table_and_add_foreign_key_constraint_after.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__create_table_and_add_foreign_key_constraint_after.snap
@@ -1,0 +1,5 @@
+---
+source: linter/src/rules/adding_foreign_key_constraint.rs
+expression: lint_sql(sql)
+---
+[]

--- a/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__create_table_and_add_foreign_key_constraint_after_with_assume_in_transaction.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__create_table_and_add_foreign_key_constraint_after_with_assume_in_transaction.snap
@@ -1,0 +1,5 @@
+---
+source: linter/src/rules/adding_foreign_key_constraint.rs
+expression: lint_sql_assuming_in_transaction(sql)
+---
+[]

--- a/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__create_table_with_foreign_key_constraint.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__adding_foreign_key_constraint__test_rules__create_table_with_foreign_key_constraint.snap
@@ -1,0 +1,5 @@
+---
+source: linter/src/rules/adding_foreign_key_constraint.rs
+expression: lint_sql(sql)
+---
+[]


### PR DESCRIPTION
I started to put this together to address an extension of #220: the case where the table is created and a foreign key constraint is added in the same transaction. We use a tool that generates SQL from a language-specific mapper and it separates these into two steps:

```sql
-- instead of 
CREATE TABLE foo (
  user_id BIGINT REFERENCES users (id),
  ...
);

-- or
CREATE TABLE foo (
  user_id BIGINT,
  ...
  CONSTRAINT user_id_fk FOREIGN KEY user_id REFERENCES users (id)
);

-- it generates
CREATE TABLE foo (
  user_id BIGINT,
  ...
);
ALTER TABLE foo ADD CONSTRAINT user_id_fk FOREIGN KEY user_id REFERENCES users (id);
```

In this case, there should be no table scan or it should be near instantaneous. I put together this change to adapt this rule to recognize this, but there are some shortcomings.

If someone were to have INSERT or COPY statements between the table creation and the foreign key addition, then the table scan becomes a real risk again. It also seems fairly intractable to determine this, as INSERT/COPY statements could be hidden in a stored procedure or function that is executed between the CREATE TABLE and ALTER TABLE commands.

Anyhow, I wanted to put this up for consideration and see if you had any thoughts on that problem. I imagine the INSERT/COPY between creation and foreign key addition would be pretty unlikely, but would cause Squawk to produce a false-negative, which is unsettling.