### PR TITLE
Introduce a new rule to lint nested transactions

### DIFF
--- a/docs/docs/transaction-nesting.md
+++ b/docs/docs/transaction-nesting.md
@@ -1,0 +1,18 @@
+---
+id: transaction-nesting
+title: transaction-nesting
+---
+
+## problem
+
+PostgreSQL doesn't support transactions that are nested inside of each other. There is only one transaction running per session. The server will warn if `BEGIN`, `START TRANSACTION`, `COMMIT`, `ROLLBACK`, or `END` statements are repeated.
+
+If you use the `--assume-in-transaction` flag when running Squawk or set `assume-in-transaction = true` in your config file, Squawk assumes that your migration tool will wrap each migration file in a transaction at runtime. Therefore, explicit calls to `BEGIN` and `COMMIT` should be avoided, as these may disrupt what the tool is doing and cause unpredictable results.
+
+## solution
+
+Fix by removing the offending statements, verifying that the transaction start and end are being set correctly.
+
+If you are using `assume-in-transaction`, split each transaction into its own file.
+
+Alternatively, if your migration tool supports explicitly managing transactions, you could use that along with `BEGIN` and `COMMIT` statements in your migration file and not set `assume-in-transaction` for Squawk.

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -10,6 +10,7 @@ module.exports = {
       "ban-char-field",
       "ban-drop-database",
       "ban-drop-not-null",
+      "ban-drop-table",
       "changing-column-type",
       "constraint-missing-not-valid",
       "disallowed-unique-constraint",
@@ -24,7 +25,7 @@ module.exports = {
       "renaming-table",
       "require-concurrent-index-creation",
       "require-concurrent-index-deletion",
-      "ban-drop-table",
+      "transaction-nesting",
       // generator::new-rule-above
     ],
   },

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -168,6 +168,11 @@ const rules = [
     description:
       "Prevent blocking reads/writes to table while index is dropped.",
   },
+  {
+    name: "transaction-nesting",
+    tags: ["locking"],
+    description: "Ensure migrations use transactions correctly.",
+  },
   // generator::new-rule-above
 ]
 

--- a/linter/src/lib.rs
+++ b/linter/src/lib.rs
@@ -11,6 +11,7 @@ use crate::errors::CheckSqlError;
 use crate::rules::ban_drop_not_null;
 use crate::rules::prefer_big_int;
 use crate::rules::prefer_identity;
+use crate::rules::transaction_nesting;
 use crate::rules::{
     adding_field_with_default, adding_foreign_key_constraint, adding_not_nullable_field,
     adding_primary_key_constraint, ban_char_type, ban_drop_column, ban_drop_database,
@@ -323,6 +324,18 @@ lazy_static! {
             ),
             ViolationMessage::Help(
                 "Delete the index CONCURRENTLY.".into()
+            ),
+        ],
+    },
+    SquawkRule {
+        name: RuleViolationKind::TransactionNesting,
+        func: transaction_nesting,
+        messages: vec![
+            ViolationMessage::Note(
+                "There is an existing transaction already in progress.".into()
+            ),
+            ViolationMessage::Help(
+                "COMMIT the previous transaction before issuing a BEGIN or START TRANSACTION statement.".into()
             ),
         ],
     },

--- a/linter/src/rules/mod.rs
+++ b/linter/src/rules/mod.rs
@@ -46,3 +46,5 @@ pub mod ban_drop_table;
 pub use ban_drop_table::*;
 pub mod ban_drop_not_null;
 pub use ban_drop_not_null::*;
+pub mod transaction_nesting;
+pub use transaction_nesting::*;

--- a/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__begin_repeated.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__begin_repeated.snap
@@ -1,0 +1,23 @@
+---
+source: linter/src/rules/transaction_nesting.rs
+expression: lint_sql(bad_sql)
+---
+[
+    RuleViolation {
+        kind: TransactionNesting,
+        span: Span {
+            start: 7,
+            len: Some(
+                6,
+            ),
+        },
+        messages: [
+            Note(
+                "There is an existing transaction already in progress.",
+            ),
+            Help(
+                "COMMIT the previous transaction before issuing a BEGIN or START TRANSACTION statement.",
+            ),
+        ],
+    },
+]

--- a/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__begin_with_assume_in_transaction.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__begin_with_assume_in_transaction.snap
@@ -1,0 +1,23 @@
+---
+source: linter/src/rules/transaction_nesting.rs
+expression: lint_sql_assuming_in_transaction(bad_sql)
+---
+[
+    RuleViolation {
+        kind: TransactionNesting,
+        span: Span {
+            start: 0,
+            len: Some(
+                6,
+            ),
+        },
+        messages: [
+            Note(
+                "There is an existing transaction already in progress, managed by your migration tool.",
+            ),
+            Help(
+                "Put migration statements in separate files to have them be in separate transactions or don't use the assume-in-transaction setting.",
+            ),
+        ],
+    },
+]

--- a/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__commit_repeated.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__commit_repeated.snap
@@ -1,0 +1,23 @@
+---
+source: linter/src/rules/transaction_nesting.rs
+expression: lint_sql(bad_sql)
+---
+[
+    RuleViolation {
+        kind: TransactionNesting,
+        span: Span {
+            start: 25,
+            len: Some(
+                7,
+            ),
+        },
+        messages: [
+            Note(
+                "There is no transaction to COMMIT or ROLLBACK.",
+            ),
+            Help(
+                "BEGIN a transaction at an earlier point in the migration or remove this statement.",
+            ),
+        ],
+    },
+]

--- a/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__commit_with_assume_in_transaction.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__commit_with_assume_in_transaction.snap
@@ -1,0 +1,23 @@
+---
+source: linter/src/rules/transaction_nesting.rs
+expression: lint_sql_assuming_in_transaction(bad_sql)
+---
+[
+    RuleViolation {
+        kind: TransactionNesting,
+        span: Span {
+            start: 10,
+            len: Some(
+                7,
+            ),
+        },
+        messages: [
+            Note(
+                "Attempting to end the transaction that is managed by your migration tool.",
+            ),
+            Help(
+                "Put migration statements in separate files to have them be in separate transactions or don't use the assume-in-transaction setting.",
+            ),
+        ],
+    },
+]

--- a/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__rollback_with_assume_in_transaction.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__transaction_nesting__test_rules__rollback_with_assume_in_transaction.snap
@@ -1,0 +1,23 @@
+---
+source: linter/src/rules/transaction_nesting.rs
+expression: lint_sql_assuming_in_transaction(bad_sql)
+---
+[
+    RuleViolation {
+        kind: TransactionNesting,
+        span: Span {
+            start: 10,
+            len: Some(
+                90,
+            ),
+        },
+        messages: [
+            Note(
+                "Attempting to end the transaction that is managed by your migration tool.",
+            ),
+            Help(
+                "Put migration statements in separate files to have them be in separate transactions or don't use the assume-in-transaction setting.",
+            ),
+        ],
+    },
+]

--- a/linter/src/rules/transaction_nesting.rs
+++ b/linter/src/rules/transaction_nesting.rs
@@ -1,0 +1,178 @@
+use crate::versions::Version;
+use crate::violations::{RuleViolation, RuleViolationKind};
+use crate::ViolationMessage;
+
+use squawk_parser::ast::{RawStmt, Stmt, TransactionStmtKind};
+
+#[must_use]
+pub fn transaction_nesting(
+    tree: &[RawStmt],
+    _pg_version: Option<Version>,
+    assume_in_transaction: bool,
+) -> Vec<RuleViolation> {
+    let mut errs = vec![];
+    let mut in_explicit_transaction = false;
+    let assume_in_transaction_help = ViolationMessage::Help(
+        "Put migration statements in separate files to have them be in separate transactions or \
+        don't use the assume-in-transaction setting."
+            .into(),
+    );
+
+    for raw_stmt in tree {
+        match &raw_stmt.stmt {
+            Stmt::TransactionStmt(stmt) => match stmt.kind {
+                TransactionStmtKind::Begin | TransactionStmtKind::Start => {
+                    if assume_in_transaction {
+                        errs.push(RuleViolation::new(
+                                RuleViolationKind::TransactionNesting,
+                                raw_stmt.into(),
+                                Some(vec![
+                                    ViolationMessage::Note(
+                                        "There is an existing transaction already in progress, managed by your migration tool.".into()
+                                    ),
+                                    assume_in_transaction_help.clone(),
+                                ])
+                            ));
+                    } else if in_explicit_transaction {
+                        errs.push(RuleViolation::new(
+                            RuleViolationKind::TransactionNesting,
+                            raw_stmt.into(),
+                            None,
+                        ));
+                    }
+                    in_explicit_transaction = true;
+                }
+                TransactionStmtKind::Commit | TransactionStmtKind::Rollback => {
+                    if assume_in_transaction {
+                        errs.push(RuleViolation::new(
+                                RuleViolationKind::TransactionNesting,
+                                raw_stmt.into(),
+                                Some(vec![
+                                    ViolationMessage::Note(
+                                        "Attempting to end the transaction that is managed by your migration tool.".into()
+                                    ),
+                                    assume_in_transaction_help.clone(),
+                                ])
+                            ));
+                    } else if !in_explicit_transaction {
+                        errs.push(RuleViolation::new(
+                                RuleViolationKind::TransactionNesting,
+                                raw_stmt.into(),
+                                Some(vec![
+                                    ViolationMessage::Note(
+                                        "There is no transaction to COMMIT or ROLLBACK.".into()
+                                    ),
+                                    ViolationMessage::Help(
+                                        "BEGIN a transaction at an earlier point in the migration or remove this statement.".into()
+                                    ),
+                                ])
+                            ));
+                    }
+                    in_explicit_transaction = false;
+                }
+                _ => continue,
+            },
+            _ => continue,
+        }
+    }
+    errs
+}
+
+#[cfg(test)]
+mod test_rules {
+    use crate::{
+        check_sql_with_rule,
+        violations::{RuleViolation, RuleViolationKind},
+    };
+    use insta::assert_debug_snapshot;
+
+    fn lint_sql(sql: &str) -> Vec<RuleViolation> {
+        check_sql_with_rule(sql, &RuleViolationKind::TransactionNesting, None, false).unwrap()
+    }
+    fn lint_sql_assuming_in_transaction(sql: &str) -> Vec<RuleViolation> {
+        check_sql_with_rule(sql, &RuleViolationKind::TransactionNesting, None, true).unwrap()
+    }
+
+    #[test]
+    fn test_no_nesting() {
+        let ok_sql = r#"
+BEGIN;
+SELECT 1;
+COMMIT;
+  "#;
+        assert_eq!(lint_sql(ok_sql), vec![]);
+    }
+
+    #[test]
+    fn test_no_nesting_repeated() {
+        let ok_sql = r#"
+BEGIN;
+SELECT 1;
+COMMIT;
+-- This probably shouldn't be done in a migration. However, Squawk may be linting several
+-- migrations that are concatentated, so don't raise a warning here.
+BEGIN;
+SELECT 2;
+COMMIT;
+  "#;
+        assert_eq!(lint_sql(ok_sql), vec![]);
+    }
+
+    #[test]
+    fn test_no_nesting_with_assume_in_transaction() {
+        let ok_sql = r#"
+SELECT 1;
+  "#;
+        assert_eq!(lint_sql_assuming_in_transaction(ok_sql), vec![]);
+    }
+
+    #[test]
+    fn test_begin_repeated() {
+        let bad_sql = r#"
+BEGIN;
+BEGIN;
+SELECT 1;
+COMMIT;
+  "#;
+        assert_debug_snapshot!(lint_sql(bad_sql));
+    }
+
+    #[test]
+    fn test_begin_with_assume_in_transaction() {
+        let bad_sql = r#"
+BEGIN;
+SELECT 1;
+  "#;
+        assert_debug_snapshot!(lint_sql_assuming_in_transaction(bad_sql));
+    }
+
+    #[test]
+    fn test_commit_repeated() {
+        let bad_sql = r#"
+BEGIN;
+SELECT 1;
+COMMIT;
+COMMIT;
+  "#;
+        assert_debug_snapshot!(lint_sql(bad_sql));
+    }
+
+    #[test]
+    fn test_commit_with_assume_in_transaction() {
+        let bad_sql = r#"
+SELECT 1;
+COMMIT;
+  "#;
+        assert_debug_snapshot!(lint_sql_assuming_in_transaction(bad_sql));
+    }
+
+    #[test]
+    fn test_rollback_with_assume_in_transaction() {
+        let bad_sql = r#"
+SELECT 1;
+-- Not sure why rollback would be used in a migration, but test for completeness
+ROLLBACK;
+  "#;
+        assert_debug_snapshot!(lint_sql_assuming_in_transaction(bad_sql));
+    }
+}

--- a/linter/src/snapshots/squawk_linter__test_rules__rule_names_debug_snap.snap
+++ b/linter/src/snapshots/squawk_linter__test_rules__rule_names_debug_snap.snap
@@ -26,4 +26,5 @@ expression: rule_names
     "renaming-table",
     "require-concurrent-index-creation",
     "require-concurrent-index-deletion",
+    "transaction-nesting",
 ]

--- a/linter/src/snapshots/squawk_linter__test_rules__rule_names_display_snap.snap
+++ b/linter/src/snapshots/squawk_linter__test_rules__rule_names_display_snap.snap
@@ -25,3 +25,4 @@ renaming-column
 renaming-table
 require-concurrent-index-creation
 require-concurrent-index-deletion
+transaction-nesting

--- a/linter/src/violations.rs
+++ b/linter/src/violations.rs
@@ -55,6 +55,8 @@ pub enum RuleViolationKind {
     BanDropTable,
     #[serde(rename = "ban-drop-not-null")]
     BanDropNotNull,
+    #[serde(rename = "transaction-nesting")]
+    TransactionNesting,
     // generator::new-rule-above
 }
 


### PR DESCRIPTION
Since PostgreSQL doesn't support true nested transactions, this rule looks for transaction managements statements that might cause problems when running migrations, like BEGIN or COMMIT being issued multiple times. It also enforces strictness around assume-in-transaction: the migration tool is in charge of the transaction and explicit BEGIN/COMMIT statements may cause problems.