### PR TITLE
Always comment when Squawk checks a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.26.0 - 2023-12-12
+
+### Changed
+
+- `squawk upload-to-github` will always leave a pull request comment if files are evaluated. Previously if violations were resolved, stale warnings would be left in a comment. (#330)
+
 ## v0.25.0 - 2023-12-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,7 +1595,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "atty",
  "base64 0.12.3",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squawk"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -191,7 +191,9 @@ pub fn check_and_comment_on_pr(
         pg_version,
         assume_in_transaction,
     )?;
-    if file_results.is_empty() {
+
+    // We should only leave a comment when there are files checked.
+    if paths.is_empty() {
         info!("no files checked, exiting");
         return Ok(());
     }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           {
             squawk = final.rustPlatform.buildRustPackage {
               pname = "squawk";
-              version = "0.25.0";
+              version = "0.26.0";
 
               cargoLock = {
                 lockFile = ./Cargo.lock;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squawk-cli",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "linter for PostgreSQL, focused on migrations",
   "repository": "git@github.com:sbdchd/squawk.git",
   "author": "Steve Dignam <steve@dignam.xyz>",


### PR DESCRIPTION
Previously we would only add or update a comment if violations found. In cases where violations were resolved, this would leave stale warnings in comments.

Now we will always comment as long as files are found and checked.

There is a slight edge case where if a file is no longer in the pull request, the comment won't be updated.

related: #326