### PR TITLE
Issue-338: Adjust handling of ban-concurrent-index-creation-in-transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.28.0 - 2024-01-12
+
+### Changed
+
+- add exceptions for `ban-concurrent-index-creation-in-transaction` to handle golang-migrate. Thanks @janrueth! (#339)
+
 ## v0.27.0 - 2024-01-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,7 +1595,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "atty",
  "base64 0.12.3",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squawk"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/docs/docs/ban-concurrent-index-creation-in-transaction.md
+++ b/docs/docs/ban-concurrent-index-creation-in-transaction.md
@@ -11,7 +11,8 @@ https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CON
 
 ## solution
 
-Remove surrounding transaction markers if any, and check that the `CREATE INDEX` command is not implicitly wrapped in a transaction.
+Remove surrounding transaction markers if any.
+For migrations that are implicitly wrapped in a transaction, ensure that the `CREATE INDEX` command is the only command in the migration to allow migration tool to detect that no transaction is needed.
 
 Instead of:
 
@@ -100,6 +101,8 @@ def schema_downgrades():
 
     # <any other downgrade commands>
 ```
+
+`golang-migrate` wraps migrations in transactions but is clever enough to perform the migration if the migration file does not contain further commands next to the `CREATE INDEX` command.
 
 ## links
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           {
             squawk = final.rustPlatform.buildRustPackage {
               pname = "squawk";
-              version = "0.27.0";
+              version = "0.28.0";
 
               cargoLock = {
                 lockFile = ./Cargo.lock;

--- a/linter/src/rules/snapshots/squawk_linter__rules__ban_concurrent_index_creation_in_transaction__test_rules__adding_index_concurrently_in_transaction_with_assume_in_transaction.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__ban_concurrent_index_creation_in_transaction__test_rules__adding_index_concurrently_in_transaction_with_assume_in_transaction.snap
@@ -8,7 +8,7 @@ expression: lint_sql_assuming_in_transaction(bad_sql)
         span: Span {
             start: 0,
             len: Some(
-                92,
+                99,
             ),
         },
         messages: [

--- a/linter/src/rules/snapshots/squawk_linter__rules__ban_concurrent_index_creation_in_transaction__test_rules__adding_index_concurrently_in_transaction_with_assume_in_transaction_but_outside.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__ban_concurrent_index_creation_in_transaction__test_rules__adding_index_concurrently_in_transaction_with_assume_in_transaction_but_outside.snap
@@ -1,0 +1,6 @@
+---
+source: linter/src/rules/ban_concurrent_index_creation_in_transaction.rs
+expression: lint_sql_assuming_in_transaction(ok_sql)
+
+---
+[]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squawk-cli",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "linter for PostgreSQL, focused on migrations",
   "repository": "git@github.com:sbdchd/squawk.git",
   "author": "Steve Dignam <steve@dignam.xyz>",


### PR DESCRIPTION
This changes the logic of `ban-concurrent-index-creation-in-transaction` when `assume_in_transaction` is set. Tools like `golang-migrate` always wrap migrations in transactions but support individual statements like `CREATE INDEX CONCURRENTLY` by not wrapping them in transactions.

To support this, this commit alters the logic of `ban-concurrent-index-creation-in-transaction` to allow a standalone index create command even when `assume_in_transaction` is `true`.