### PR TITLE
feat: add a flag & config for skipping path glob patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- added `--excluded-paths` flag to ignore paths when searching for files (#350). Thanks @rdaniels6813!
+- added `--excluded-paths` flag and `excluded_paths = ["example.sql"]` configuration option to ignore paths when searching for files (#350). Thanks @rdaniels6813!
 
 ## v0.28.0 - 2024-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.29.0 - 2024-05-30
+
+### Added
+
+- added `--excluded-paths` flag to ignore paths when searching for files (#350). Thanks @rdaniels6813!
+
 ## v0.28.0 - 2024-01-12
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,9 +470,9 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1539,6 +1539,7 @@ dependencies = [
  "atty",
  "base64 0.12.3",
  "console",
+ "glob",
  "insta",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,7 +1534,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "squawk"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "atty",
  "base64 0.12.3",

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ OPTIONS:
         --dump-ast <ast-format>
             Output AST in JSON [possible values: Raw, Parsed, Debug]
 
+        --exclude-path <excluded-path>...
+            Paths to exclude
+
+            For example: --exclude-path=005_user_ids.sql --exclude-path=009_account_emails.sql
+
+            --exclude-path='*user_ids.sql'
+
     -e, --exclude <rule>...
             Exclude specific warnings
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,6 +27,7 @@ squawk-parser = { version = "0.0.0", path = "../parser" }
 squawk-linter = { version = "0.0.0", path = "../linter" }
 squawk-github = { version = "0.0.0", path = "../github" }
 toml = "0.5.9"
+glob = "0.3.1"
 
 [dev-dependencies]
 insta = "0.16.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squawk"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Steve Dignam <steve@dignam.xyz>"]
 edition = "2018"
 license = "GPL-3.0"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -39,6 +39,8 @@ impl std::fmt::Display for ConfigError {
 #[derive(Debug, Default, Deserialize)]
 pub struct Config {
     #[serde(default)]
+    pub excluded_paths: Vec<String>,
+    #[serde(default)]
     pub excluded_rules: Vec<RuleViolationKind>,
     #[serde(default)]
     pub pg_version: Option<Version>,
@@ -98,6 +100,7 @@ mod test_config {
         let squawk_toml = NamedTempFile::new().expect("generate tempFile");
         let file = r#"
 pg_version = "19.1"
+excluded_paths = ["example.sql"]
 excluded_rules = ["require-concurrent-index-creation"]
 assume_in_transaction = true
         
@@ -120,6 +123,16 @@ pg_version = "19.1"
         let squawk_toml = NamedTempFile::new().expect("generate tempFile");
         let file = r#"
 excluded_rules = ["require-concurrent-index-creation"]
+        
+        "#;
+        fs::write(&squawk_toml, file).expect("Unable to write file");
+        assert_debug_snapshot!(Config::parse(Some(squawk_toml.path().to_path_buf())));
+    }
+    #[test]
+    fn test_load_excluded_paths() {
+        let squawk_toml = NamedTempFile::new().expect("generate tempFile");
+        let file = r#"
+excluded_paths = ["example.sql"]
         
         "#;
         fs::write(&squawk_toml, file).expect("Unable to write file");

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -44,9 +44,11 @@ struct Opt {
     /// Paths to exclude
     ///
     /// For example:
-    /// --exclude-paths 202401*.sql
-    #[structopt(long = "exclude-paths", use_delimiter = true)]
-    excluded_paths: Option<Vec<String>>,
+    /// --exclude-path=005_user_ids.sql --exclude-path=009_account_emails.sql
+    ///
+    /// --exclude-path='*user_ids.sql'
+    #[structopt(long = "exclude-path")]
+    excluded_path: Option<Vec<String>>,
     /// Exclude specific warnings
     ///
     /// For example:
@@ -124,8 +126,8 @@ fn main() {
         conf.excluded_rules
     };
 
-    // the --exclude-paths flag completely overrides the configuration file.
-    let excluded_paths = if let Some(excluded_paths) = opts.excluded_paths {
+    // the --exclude-path flag completely overrides the configuration file.
+    let excluded_paths = if let Some(excluded_paths) = opts.excluded_path {
         excluded_paths
     } else {
         conf.excluded_paths

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -190,13 +190,14 @@ pub fn check_files(
     }
 
     for path in paths {
-        if has_match_in_paths(path, excluded_paths) {
-            info!("skipping exluded file path: {}", path);
-            output_violations.push(ViolationContent {
-                filename: path.into(),
-                sql: String::new(),
-                violations: vec![],
-            });
+        if let Some(pattern) = excluded_paths
+            .iter()
+            .find(|&excluded| excluded.matches(path))
+        {
+            info!(
+                "skipping excluded file path: {}. pattern: {}",
+                path, pattern
+            );
         } else {
             info!("checking file path: {}", path);
             let sql = get_sql_from_path(path)?;
@@ -210,15 +211,6 @@ pub fn check_files(
         }
     }
     Ok(output_violations)
-}
-
-fn has_match_in_paths(path: &str, excluded_paths: &[Pattern]) -> bool {
-    for excluded in excluded_paths {
-        if excluded.matches(path) {
-            return true;
-        }
-    }
-    false
 }
 
 fn get_sql_from_stdin() -> Result<String, io::Error> {

--- a/cli/src/snapshots/squawk__config__test_config__load_cfg_full.snap
+++ b/cli/src/snapshots/squawk__config__test_config__load_cfg_full.snap
@@ -1,10 +1,14 @@
 ---
 source: cli/src/config.rs
 expression: "Config::parse(Some(squawk_toml.path().to_path_buf()))"
+
 ---
 Ok(
     Some(
         Config {
+            excluded_paths: [
+                "example.sql",
+            ],
             excluded_rules: [
                 RequireConcurrentIndexCreation,
             ],

--- a/cli/src/snapshots/squawk__config__test_config__load_excluded_paths.snap
+++ b/cli/src/snapshots/squawk__config__test_config__load_excluded_paths.snap
@@ -6,12 +6,12 @@ expression: "Config::parse(Some(squawk_toml.path().to_path_buf()))"
 Ok(
     Some(
         Config {
-            excluded_paths: [],
+            excluded_paths: [
+                "example.sql",
+            ],
             excluded_rules: [],
             pg_version: None,
-            assume_in_transaction: Some(
-                false,
-            ),
+            assume_in_transaction: None,
         },
     ),
 )

--- a/cli/src/snapshots/squawk__config__test_config__load_excluded_rules.snap
+++ b/cli/src/snapshots/squawk__config__test_config__load_excluded_rules.snap
@@ -1,10 +1,12 @@
 ---
 source: cli/src/config.rs
 expression: "Config::parse(Some(squawk_toml.path().to_path_buf()))"
+
 ---
 Ok(
     Some(
         Config {
+            excluded_paths: [],
             excluded_rules: [
                 RequireConcurrentIndexCreation,
             ],

--- a/cli/src/snapshots/squawk__config__test_config__load_pg_version.snap
+++ b/cli/src/snapshots/squawk__config__test_config__load_pg_version.snap
@@ -1,10 +1,12 @@
 ---
 source: cli/src/config.rs
 expression: "Config::parse(Some(squawk_toml.path().to_path_buf()))"
+
 ---
 Ok(
     Some(
         Config {
+            excluded_paths: [],
             excluded_rules: [],
             pg_version: Some(
                 Version {

--- a/cli/src/subcommand.rs
+++ b/cli/src/subcommand.rs
@@ -1,5 +1,6 @@
 use crate::reporter::{check_files, get_comment_body, CheckFilesError};
 
+use glob::Pattern;
 use log::info;
 use squawk_github::{actions, app, comment_on_pr, GitHubApi, GithubError};
 use squawk_linter::{versions::Version, violations::RuleViolationKind};
@@ -157,6 +158,7 @@ pub fn check_and_comment_on_pr(
     is_stdin: bool,
     stdin_path: Option<String>,
     root_cmd_exclude: &[RuleViolationKind],
+    root_cmd_exclude_paths: &[Pattern],
     pg_version: Option<Version>,
     assume_in_transaction: bool,
 ) -> Result<(), SquawkError> {
@@ -188,6 +190,7 @@ pub fn check_and_comment_on_pr(
         is_stdin,
         stdin_path,
         &concat(&exclude.unwrap_or_default(), root_cmd_exclude),
+        root_cmd_exclude_paths,
         pg_version,
         assume_in_transaction,
     )?;

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -21,6 +21,14 @@ Individual rules can be disabled via the `--exclude` flag
 squawk --exclude=adding-field-with-default,disallowed-unique-constraint example.sql
 ```
 
+## files
+
+Files can be excluded from linting via the `--exclude-path` flag. Glob matching is supported and the flag can be provided multiple times.
+
+```shell
+squawk --exclude-path=005_user_ids.sql --exclude-path='*user_ids.sql' migrations/*
+```
+
 ## `.squawk.toml` configuration file
 
 Rules can be disabled with a configuration file.
@@ -31,7 +39,7 @@ By default, Squawk will traverse up from the current directory to find a `.squaw
 squawk --config=~/.squawk.toml example.sql
 ```
 
-The `--exclude` and `--pg-version` flags will always be prioritized over the configuration file.
+The `--exclude`, `--exclude-path`, and `--pg-version` flags will always be prioritized over the configuration file.
 
 
 ## example `.squawk.toml` configurations
@@ -70,6 +78,10 @@ excluded_rules = [
     "require-concurrent-index-deletion",
 ]
 assume_in_transaction = true
+excluded_paths = [
+    "005_user_ids.sql",
+    "*user_ids.sql",
+]
 ```
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
           {
             squawk = final.rustPlatform.buildRustPackage {
               pname = "squawk";
-              version = "0.28.0";
+              version = "0.29.0";
 
               cargoLock = {
                 lockFile = ./Cargo.lock;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "squawk-cli",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "linter for PostgreSQL, focused on migrations",
   "repository": "git@github.com:sbdchd/squawk.git",
   "author": "Steve Dignam <steve@dignam.xyz>",


### PR DESCRIPTION
Adding a CLI flag as well as a field in the config file for skipping paths using glob patterns.  This is useful for introducing the linter on an already live service which had linter warnings on previous migrations.