### PR TITLE
fix: typo in supported platforms for `darwin-x64`

### DIFF
--- a/js/install.js
+++ b/js/install.js
@@ -46,7 +46,7 @@ const { binaryPath } = require("./helpers")
 // e.g.: https://github.com/sbdchd/squawk/releases/download/v0.1.3/squawk-darwin-x86_64
 const RELEASES_BASE_URL = "https://github.com/sbdchd/squawk/releases/download"
 
-const SUPPORTED_PLATFORMS = new Set(["darmin-x64", "darwin-arm64", "linux-x64"])
+const SUPPORTED_PLATFORMS = new Set(["darwin-x64", "darwin-arm64", "linux-x64"])
 
 /**
  * @param {string} platform


### PR DESCRIPTION
Fixes sbdchd/squawk#360