### PR TITLE
Added windows support (#368)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,8 +60,45 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # windows isn't supported by libpg_query
-  # https://github.com/lfittl/libpg_query/issues/44
+  build-windows:
+    needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/')
+    name: Windows
+
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Toolchain
+        uses: oxidecomputer/actions-rs_toolchain@ad3f86084a8a5acf2c09cb691421b31cf8af7a36 # pin@oxide/master
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-msvc
+          profile: minimal
+          override: true
+
+      - name: Cache
+        uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f # pin@v2
+
+      - name: Build
+        run: cargo build --target x86_64-pc-windows-msvc --release && mv target/x86_64-pc-windows-msvc/release/squawk.exe target/release/squawk-windows-x64.exe
+
+      - name: Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: release
+          path: target/release/squawk-windows-x64.exe
+
+      - name: Release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # pin@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            target/release/squawk-windows-x64.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-mac:
     needs: pre_job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- added support windows builds (#368)
+
 ## v1.1.2 - 2024-06-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Also it seemed like a nice project to spend more time with Rust.
 
 Note: due to `squawk`'s dependency on
 [`libpg_query`](https://github.com/lfittl/libpg_query/issues/44), `squawk`
-only supports Linux and macOS
+supports Linux, macOS and Windows
 
 ```shell
 npm install -g squawk-cli

--- a/js/install.js
+++ b/js/install.js
@@ -46,7 +46,13 @@ const { binaryPath } = require("./helpers")
 // e.g.: https://github.com/sbdchd/squawk/releases/download/v0.1.3/squawk-darwin-x86_64
 const RELEASES_BASE_URL = "https://github.com/sbdchd/squawk/releases/download"
 
-const SUPPORTED_PLATFORMS = new Set(["darwin-x64", "darwin-arm64", "linux-x64"])
+const SUPPORTED_PLATFORMS = new Set([
+  "darwin-x64",
+  "darwin-arm64",
+  "linux-x64",
+  "win32-x64",
+])
+const BINARY_NAME_OVERRIDE = new Map([["win32-x64", "squawk-windows-x64.exe"]])
 
 /**
  * @param {string} platform
@@ -56,7 +62,10 @@ function getDownloadUrl(platform, arch) {
   if (!SUPPORTED_PLATFORMS.has(`${platform}-${arch}`)) {
     return null
   }
-  return `${RELEASES_BASE_URL}/v${pkgInfo.version}/squawk-${platform}-${arch}`
+  const name =
+    BINARY_NAME_OVERRIDE.get(`${platform}-${arch}`) ||
+    `squawk-${platform}-${arch}`
+  return `${RELEASES_BASE_URL}/v${pkgInfo.version}/${name}`
 }
 
 function getNpmCache() {


### PR DESCRIPTION
#368
I tried to build the CLI on a Windows GitHub runner and it seems like there are no problems.

I tested the built binary on one of the Windows machines:

```bash
PS C:\Users\...\Downloads> .\squawk-windows-x64.exe --version
squawk 1.1.2
PS C:\Users\...\Downloads> .\squawk-windows-x64.exe 'test.sql'
test.sql:1:0: warning: adding-field-with-default

   1 | ALTER TABLE foo ADD COLUMN bar TEXT NOT NULL DEFAULT "baz";

  note: Adding a field with a VOLATILE DEFAULT requires a table rewrite with an ACCESS EXCLUSIVE lock. In Postgres versions 11+, non-VOLATILE DEFAULTs can be added without a rewrite.
  help: Add the field as nullable, then set a default, backfill, and remove nullability.

find detailed examples and solutions for each rule at https://squawkhq.com/docs/rules
PS C:\Users\...\Downloads>
```