### PR TITLE
fix python publish

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -141,8 +141,6 @@ jobs:
       - uses: actions/download-artifact@v4
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -140,7 +140,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,7 +26,6 @@ jobs:
 
   linux:
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -63,7 +62,6 @@ jobs:
 
   windows:
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -90,7 +88,6 @@ jobs:
 
   macos:
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -117,7 +114,6 @@ jobs:
 
   sdist:
     needs: pre_job
-    if: needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -26,6 +26,7 @@ jobs:
 
   linux:
     needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -62,6 +63,7 @@ jobs:
 
   windows:
     needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -88,6 +90,7 @@ jobs:
 
   macos:
     needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -114,6 +117,7 @@ jobs:
 
   sdist:
     needs: pre_job
+    if: needs.pre_job.outputs.should_skip != 'true' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -136,6 +140,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+    if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
If we remove this token, Maturin uses OIDC

https://github.com/PyO3/maturin/blob/1cd1140ca472a2ce8dac9a7f2b1cd16324af1adc/src/upload.rs#L216-L221