### PR TITLE
Add file violation count to summary report output

### DIFF
--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -321,6 +321,7 @@ pub fn fmt_tty<W: io::Write>(f: &mut W, files: &[ViolationContent]) -> Result<()
     }
     let total_violations = files.iter().map(|f| f.violations.len()).sum::<usize>();
     let files_checked = files.len();
+    let files_with_violations = files.iter().filter(|f| !f.violations.is_empty()).count();
     if total_violations == 0 {
         writeln!(
             f,
@@ -333,6 +334,16 @@ pub fn fmt_tty<W: io::Write>(f: &mut W, files: &[ViolationContent]) -> Result<()
             f,
             "find detailed examples and solutions for each rule at {}",
             style("https://squawkhq.com/docs/rules").underlined()
+        )?;
+        writeln!(
+            f,
+            "Found {total_violations} issue{plural} in {files_with_violations} file{files_plural} (checked {files_checked} {files_checked_plural})",
+            total_violations = total_violations,
+            plural = if total_violations == 1 { "" } else { "s" },
+            files_with_violations = files_with_violations,
+            files_plural = if files_with_violations == 1 { "" } else { "s" },
+            files_checked = files_checked,
+            files_checked_plural = if files_checked == 1 { "source file" } else { "source files" }
         )?;
     }
     Ok(())

--- a/cli/src/snapshots/squawk__reporter__test_reporter__display_violations_tty.snap
+++ b/cli/src/snapshots/squawk__reporter__test_reporter__display_violations_tty.snap
@@ -18,4 +18,4 @@ main.sql:3:1: warning: adding-required-field
   help: Make the field nullable or add a non-VOLATILE DEFAULT (Postgres 11+).
 
 find detailed examples and solutions for each rule at https://squawkhq.com/docs/rules
-
+Found 2 issues in 1 file (checked 1 source file)


### PR DESCRIPTION
#### What has been done:
- Added a summary message to display the number of files with violations.
- If violations are found, the report will now include the total number of violations, the number of files with violations, and the number of files checked.

#### Example of the summary message:
```
Found 2 issues in 1 file (checked 1 source file)
```

#### Why this is needed:
- Improves the clarity of the final report by adding information about the number of files with violations.
- Makes it easier to quickly identify how many files require attention, streamlining the process of addressing issues.
