### PR TITLE
Update github_app.md

### DIFF
--- a/docs/docs/github_app.md
+++ b/docs/docs/github_app.md
@@ -30,7 +30,7 @@ jobs:
   lint_migrations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Find modified migrations
         run: |
           modified_migrations=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF 'migrations/*.sql')


### PR DESCRIPTION
`actions/checkout` is now at v4

At the time of making this PR at 4.1.7.

See https://github.com/actions/checkout/releases/