### PR TITLE
fix: github_app.md

### DIFF
--- a/docs/docs/github_app.md
+++ b/docs/docs/github_app.md
@@ -31,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Find modified migrations
         run: |
           modified_migrations=$(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF 'migrations/*.sql')


### PR DESCRIPTION
Fix mistake added in #381, where updating to `actions/checkout` past `v1` would mean the example stops working.

This is due to change in the checkout functionality in `actions/checkout` introduced in v2 (beta). See https://github.com/actions/checkout/blob/main/CHANGELOG.md#v2-beta