### PR TITLE
Fix issue #385

### DIFF
--- a/linter/src/rules/ban_concurrent_index_creation_in_transaction.rs
+++ b/linter/src/rules/ban_concurrent_index_creation_in_transaction.rs
@@ -14,7 +14,10 @@ pub fn ban_concurrent_index_creation_in_transaction(
     for raw_stmt in tree {
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => {
-                if (stmt.kind == TransactionStmtKind::Begin || stmt.kind == TransactionStmtKind::Start) && !in_transaction {
+                if (stmt.kind == TransactionStmtKind::Begin
+                    || stmt.kind == TransactionStmtKind::Start)
+                    && !in_transaction
+                {
                     in_transaction = true;
                 }
                 if stmt.kind == TransactionStmtKind::Commit {

--- a/linter/src/rules/ban_concurrent_index_creation_in_transaction.rs
+++ b/linter/src/rules/ban_concurrent_index_creation_in_transaction.rs
@@ -14,7 +14,7 @@ pub fn ban_concurrent_index_creation_in_transaction(
     for raw_stmt in tree {
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => {
-                if stmt.kind == TransactionStmtKind::Begin && !in_transaction {
+                if (stmt.kind == TransactionStmtKind::Begin || stmt.kind == TransactionStmtKind::Start) && !in_transaction {
                     in_transaction = true;
                 }
                 if stmt.kind == TransactionStmtKind::Commit {

--- a/linter/src/rules/constraint_missing_not_valid.rs
+++ b/linter/src/rules/constraint_missing_not_valid.rs
@@ -16,7 +16,10 @@ fn not_valid_validate_in_transaction(tree: &[RawStmt], assume_in_transaction: bo
     for raw_stmt in tree {
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => {
-                if (stmt.kind == TransactionStmtKind::Begin || stmt.kind == TransactionStmtKind::Start) && !in_transaction {
+                if (stmt.kind == TransactionStmtKind::Begin
+                    || stmt.kind == TransactionStmtKind::Start)
+                    && !in_transaction
+                {
                     in_transaction = true;
                     not_valid_names.clear();
                 }

--- a/linter/src/rules/constraint_missing_not_valid.rs
+++ b/linter/src/rules/constraint_missing_not_valid.rs
@@ -16,7 +16,7 @@ fn not_valid_validate_in_transaction(tree: &[RawStmt], assume_in_transaction: bo
     for raw_stmt in tree {
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => {
-                if stmt.kind == TransactionStmtKind::Begin && !in_transaction {
+                if (stmt.kind == TransactionStmtKind::Begin || stmt.kind == TransactionStmtKind::Start) && !in_transaction {
                     in_transaction = true;
                     not_valid_names.clear();
                 }

--- a/linter/src/rules/prefer_robust_stmts.rs
+++ b/linter/src/rules/prefer_robust_stmts.rs
@@ -38,7 +38,7 @@ pub fn prefer_robust_stmts(
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => match stmt.kind {
                 TransactionStmtKind::Begin | TransactionStmtKind::Start => {
-                    inside_transaction = true
+                    inside_transaction = true;
                 }
                 TransactionStmtKind::Commit => inside_transaction = false,
                 _ => continue,

--- a/linter/src/rules/prefer_robust_stmts.rs
+++ b/linter/src/rules/prefer_robust_stmts.rs
@@ -37,7 +37,9 @@ pub fn prefer_robust_stmts(
     for raw_stmt in tree {
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => match stmt.kind {
-                TransactionStmtKind::Begin | TransactionStmtKind::Start => inside_transaction = true,
+                TransactionStmtKind::Begin | TransactionStmtKind::Start => {
+                    inside_transaction = true
+                }
                 TransactionStmtKind::Commit => inside_transaction = false,
                 _ => continue,
             },

--- a/linter/src/rules/prefer_robust_stmts.rs
+++ b/linter/src/rules/prefer_robust_stmts.rs
@@ -37,7 +37,7 @@ pub fn prefer_robust_stmts(
     for raw_stmt in tree {
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => match stmt.kind {
-                TransactionStmtKind::Begin => inside_transaction = true,
+                TransactionStmtKind::Begin | TransactionStmtKind::Start => inside_transaction = true,
                 TransactionStmtKind::Commit => inside_transaction = false,
                 _ => continue,
             },

--- a/linter/src/rules/utils.rs
+++ b/linter/src/rules/utils.rs
@@ -13,7 +13,7 @@ pub fn tables_created_in_transaction(
     for raw_stmt in tree {
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => match stmt.kind {
-                TransactionStmtKind::Begin => inside_transaction = true,
+                TransactionStmtKind::Begin | TransactionStmtKind::Start => inside_transaction = true,
                 TransactionStmtKind::Commit => inside_transaction = false,
                 _ => continue,
             },

--- a/linter/src/rules/utils.rs
+++ b/linter/src/rules/utils.rs
@@ -14,7 +14,7 @@ pub fn tables_created_in_transaction(
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => match stmt.kind {
                 TransactionStmtKind::Begin | TransactionStmtKind::Start => {
-                    inside_transaction = true
+                    inside_transaction = true;
                 }
                 TransactionStmtKind::Commit => inside_transaction = false,
                 _ => continue,

--- a/linter/src/rules/utils.rs
+++ b/linter/src/rules/utils.rs
@@ -13,7 +13,9 @@ pub fn tables_created_in_transaction(
     for raw_stmt in tree {
         match &raw_stmt.stmt {
             Stmt::TransactionStmt(stmt) => match stmt.kind {
-                TransactionStmtKind::Begin | TransactionStmtKind::Start => inside_transaction = true,
+                TransactionStmtKind::Begin | TransactionStmtKind::Start => {
+                    inside_transaction = true
+                }
                 TransactionStmtKind::Commit => inside_transaction = false,
                 _ => continue,
             },


### PR DESCRIPTION
Adds missing check for `TransactionStmtKind::Start` when verifying the existence of transactions as this is the same as using BEGIN: https://www.postgresql.org/docs/current/sql-begin.html

Fixes https://github.com/sbdchd/squawk/issues/385