### PR TITLE
Use ColumnDef position in lint report

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -49,6 +49,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
+          maturin-version: v1.7.1
           working-directory: cli
           args: --release --out dist ${{ matrix.platform.maturin-options }}
           manylinux: ${{ matrix.platform.manylinux }}

--- a/cli/src/reporter.rs
+++ b/cli/src/reporter.rs
@@ -386,13 +386,18 @@ pub fn pretty_violations(
                 #[allow(clippy::cast_sign_loss)]
                 let start = start as usize;
 
-                #[allow(clippy::cast_sign_loss)]
-                let len = len.unwrap_or(0) as usize;
-
                 // 1-indexed
-                let lineno = sql[..start].lines().count() + 1;
+                // remove the leading whitespace on last line
+                let lineno = sql[..start].trim_end().lines().count() + 1;
 
-                let content = &sql[start..=start + len];
+                let content = if let Some(len) = len {
+                    #[allow(clippy::cast_sign_loss)]
+                    &sql[start..=start + len as usize]
+                } else {
+                    // Use current line
+                    let tail = sql[start..].find('\n').unwrap_or(sql.len() - start);
+                    &sql[start..=start + tail]
+                };
 
                 // TODO(sbdchd): could remove the leading whitespace and comments to
                 // get cleaner reports

--- a/linter/src/rules/ban_char_field.rs
+++ b/linter/src/rules/ban_char_field.rs
@@ -22,7 +22,7 @@ pub fn ban_char_type(
                             if field_type_name.string.sval == "bpchar" {
                                 errs.push(RuleViolation::new(
                                     RuleViolationKind::BanCharField,
-                                    raw_stmt.into(),
+                                    column_def.into(),
                                     None,
                                 ));
                             }

--- a/linter/src/rules/prefer_bigint_over_int.rs
+++ b/linter/src/rules/prefer_bigint_over_int.rs
@@ -18,7 +18,7 @@ pub fn prefer_bigint_over_int(
     let mut errs = vec![];
     for raw_stmt in tree {
         for column in columns_create_or_modified(&raw_stmt.stmt) {
-            check_column_def(&mut errs, raw_stmt, column);
+            check_column_def(&mut errs, column);
         }
     }
     errs
@@ -29,12 +29,12 @@ lazy_static! {
         HashSet::from(["integer", "int4", "serial", "serial4",]);
 }
 
-fn check_column_def(errs: &mut Vec<RuleViolation>, raw_stmt: &RawStmt, column_def: &ColumnDef) {
+fn check_column_def(errs: &mut Vec<RuleViolation>, column_def: &ColumnDef) {
     if let Some(column_name) = column_def.type_name.names.last() {
         if INT_TYPES.contains(column_name.string.sval.as_str()) {
             errs.push(RuleViolation::new(
                 RuleViolationKind::PreferBigintOverInt,
-                raw_stmt.into(),
+                column_def.into(),
                 None,
             ));
         }

--- a/linter/src/rules/prefer_bigint_over_smallint.rs
+++ b/linter/src/rules/prefer_bigint_over_smallint.rs
@@ -18,7 +18,7 @@ pub fn prefer_bigint_over_smallint(
     let mut errs = vec![];
     for raw_stmt in tree {
         for column in columns_create_or_modified(&raw_stmt.stmt) {
-            check_column_def(&mut errs, raw_stmt, column);
+            check_column_def(&mut errs, column);
         }
     }
     errs
@@ -29,12 +29,12 @@ lazy_static! {
         HashSet::from(["smallint", "int2", "smallserial", "serial2",]);
 }
 
-fn check_column_def(errs: &mut Vec<RuleViolation>, raw_stmt: &RawStmt, column_def: &ColumnDef) {
+fn check_column_def(errs: &mut Vec<RuleViolation>, column_def: &ColumnDef) {
     if let Some(column_name) = column_def.type_name.names.last() {
         if SMALL_INT_TYPES.contains(column_name.string.sval.as_str()) {
             errs.push(RuleViolation::new(
                 RuleViolationKind::PreferBigintOverSmallint,
-                raw_stmt.into(),
+                column_def.into(),
                 None,
             ));
         }

--- a/linter/src/rules/prefer_identity.rs
+++ b/linter/src/rules/prefer_identity.rs
@@ -18,7 +18,7 @@ pub fn prefer_identity(
     let mut errs = vec![];
     for raw_stmt in tree {
         for column in columns_create_or_modified(&raw_stmt.stmt) {
-            check_column_def(&mut errs, raw_stmt, column);
+            check_column_def(&mut errs, column);
         }
     }
     errs
@@ -35,12 +35,12 @@ lazy_static! {
     ]);
 }
 
-fn check_column_def(errs: &mut Vec<RuleViolation>, raw_stmt: &RawStmt, column_def: &ColumnDef) {
+fn check_column_def(errs: &mut Vec<RuleViolation>, column_def: &ColumnDef) {
     if let Some(column_name) = column_def.type_name.names.last() {
         if SERIAL_TYPES.contains(column_name.string.sval.as_str()) {
             errs.push(RuleViolation::new(
                 RuleViolationKind::PreferIdentity,
-                raw_stmt.into(),
+                column_def.into(),
                 None,
             ));
         }

--- a/linter/src/rules/prefer_text_field.rs
+++ b/linter/src/rules/prefer_text_field.rs
@@ -19,19 +19,19 @@ pub fn prefer_text_field(
     let mut errs = vec![];
     for raw_stmt in tree {
         for column in columns_create_or_modified(&raw_stmt.stmt) {
-            check_column_def(&mut errs, raw_stmt, column);
+            check_column_def(&mut errs, column);
         }
     }
     errs
 }
 
-fn check_column_def(errs: &mut Vec<RuleViolation>, raw_stmt: &RawStmt, column_def: &ColumnDef) {
+fn check_column_def(errs: &mut Vec<RuleViolation>, column_def: &ColumnDef) {
     let type_name = &column_def.type_name;
     for field_type_name in &type_name.names {
         if field_type_name.string.sval == "varchar" && !type_name.typmods.is_empty() {
             errs.push(RuleViolation::new(
                 RuleViolationKind::PreferTextField,
-                raw_stmt.into(),
+                column_def.into(),
                 None,
             ));
         }
@@ -68,10 +68,8 @@ COMMIT;
             RuleViolation {
                 kind: PreferTextField,
                 span: Span {
-                    start: 7,
-                    len: Some(
-                        123,
-                    ),
+                    start: 77,
+                    len: None,
                 },
                 messages: [
                     Note(
@@ -104,10 +102,8 @@ COMMIT;
             RuleViolation {
                 kind: PreferTextField,
                 span: Span {
-                    start: 7,
-                    len: Some(
-                        127,
-                    ),
+                    start: 103,
+                    len: None,
                 },
                 messages: [
                     Note(

--- a/linter/src/rules/prefer_timestamptz.rs
+++ b/linter/src/rules/prefer_timestamptz.rs
@@ -16,18 +16,18 @@ pub fn prefer_timestamptz(
     let mut errs = vec![];
     for raw_stmt in tree {
         for column in columns_create_or_modified(&raw_stmt.stmt) {
-            check_column_def(&mut errs, raw_stmt, column);
+            check_column_def(&mut errs, column);
         }
     }
     errs
 }
 
-fn check_column_def(errs: &mut Vec<RuleViolation>, raw_stmt: &RawStmt, column_def: &ColumnDef) {
+fn check_column_def(errs: &mut Vec<RuleViolation>, column_def: &ColumnDef) {
     if let Some(type_name) = column_def.type_name.names.last() {
         if type_name.string.sval == "timestamp" {
             errs.push(RuleViolation::new(
                 RuleViolationKind::PreferTimestampTz,
-                raw_stmt.into(),
+                column_def.into(),
                 None,
             ));
         }

--- a/linter/src/rules/snapshots/squawk_linter__rules__ban_char_field__test_rules__creating_table_with_char_errors.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__ban_char_field__test_rules__creating_table_with_char_errors.snap
@@ -6,10 +6,8 @@ expression: lint_sql(sql)
     RuleViolation {
         kind: BanCharField,
         span: Span {
-            start: 7,
-            len: Some(
-                194,
-            ),
+            start: 76,
+            len: None,
         },
         messages: [
             Help(
@@ -20,10 +18,8 @@ expression: lint_sql(sql)
     RuleViolation {
         kind: BanCharField,
         span: Span {
-            start: 7,
-            len: Some(
-                194,
-            ),
+            start: 108,
+            len: None,
         },
         messages: [
             Help(
@@ -34,10 +30,8 @@ expression: lint_sql(sql)
     RuleViolation {
         kind: BanCharField,
         span: Span {
-            start: 7,
-            len: Some(
-                194,
-            ),
+            start: 144,
+            len: None,
         },
         messages: [
             Help(
@@ -48,10 +42,8 @@ expression: lint_sql(sql)
     RuleViolation {
         kind: BanCharField,
         span: Span {
-            start: 7,
-            len: Some(
-                194,
-            ),
+            start: 173,
+            len: None,
         },
         messages: [
             Help(

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_big_int__test_rules__create_table_bad.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_big_int__test_rules__create_table_bad.snap
@@ -6,10 +6,8 @@ expression: res
     RuleViolation {
         kind: PreferBigInt,
         span: Span {
-            start: 0,
-            len: Some(
-                39,
-            ),
+            start: 26,
+            len: None,
         },
         messages: [
             Note(
@@ -23,10 +21,8 @@ expression: res
     RuleViolation {
         kind: PreferBigInt,
         span: Span {
-            start: 40,
-            len: Some(
-                35,
-            ),
+            start: 66,
+            len: None,
         },
         messages: [
             Note(
@@ -40,10 +36,8 @@ expression: res
     RuleViolation {
         kind: PreferBigInt,
         span: Span {
-            start: 76,
-            len: Some(
-                38,
-            ),
+            start: 102,
+            len: None,
         },
         messages: [
             Note(
@@ -57,10 +51,8 @@ expression: res
     RuleViolation {
         kind: PreferBigInt,
         span: Span {
-            start: 115,
-            len: Some(
-                35,
-            ),
+            start: 141,
+            len: None,
         },
         messages: [
             Note(
@@ -74,10 +66,8 @@ expression: res
     RuleViolation {
         kind: PreferBigInt,
         span: Span {
-            start: 151,
-            len: Some(
-                37,
-            ),
+            start: 177,
+            len: None,
         },
         messages: [
             Note(
@@ -91,10 +81,8 @@ expression: res
     RuleViolation {
         kind: PreferBigInt,
         span: Span {
-            start: 189,
-            len: Some(
-                38,
-            ),
+            start: 215,
+            len: None,
         },
         messages: [
             Note(
@@ -108,10 +96,8 @@ expression: res
     RuleViolation {
         kind: PreferBigInt,
         span: Span {
-            start: 228,
-            len: Some(
-                38,
-            ),
+            start: 254,
+            len: None,
         },
         messages: [
             Note(
@@ -125,10 +111,8 @@ expression: res
     RuleViolation {
         kind: PreferBigInt,
         span: Span {
-            start: 267,
-            len: Some(
-                42,
-            ),
+            start: 293,
+            len: None,
         },
         messages: [
             Note(

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_big_int__test_rules__create_table_many_errors.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_big_int__test_rules__create_table_many_errors.snap
@@ -1,0 +1,36 @@
+---
+source: linter/src/rules/prefer_big_int.rs
+expression: res
+---
+[
+    RuleViolation {
+        kind: PreferBigInt,
+        span: Span {
+            start: 26,
+            len: None,
+        },
+        messages: [
+            Note(
+                "Hitting the max 32 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+    RuleViolation {
+        kind: PreferBigInt,
+        span: Span {
+            start: 43,
+            len: None,
+        },
+        messages: [
+            Note(
+                "Hitting the max 32 bit integer is possible and may break your application.",
+            ),
+            Help(
+                "Use 64bit integer values instead to prevent hitting this limit.",
+            ),
+        ],
+    },
+]

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_bigint_over_int__test_rules__create_table_bad.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_bigint_over_int__test_rules__create_table_bad.snap
@@ -6,10 +6,8 @@ expression: res
     RuleViolation {
         kind: PreferBigintOverInt,
         span: Span {
-            start: 0,
-            len: Some(
-                38,
-            ),
+            start: 26,
+            len: None,
         },
         messages: [
             Note(
@@ -23,10 +21,8 @@ expression: res
     RuleViolation {
         kind: PreferBigintOverInt,
         span: Span {
-            start: 39,
-            len: Some(
-                35,
-            ),
+            start: 65,
+            len: None,
         },
         messages: [
             Note(
@@ -40,10 +36,8 @@ expression: res
     RuleViolation {
         kind: PreferBigintOverInt,
         span: Span {
-            start: 75,
-            len: Some(
-                37,
-            ),
+            start: 101,
+            len: None,
         },
         messages: [
             Note(
@@ -57,10 +51,8 @@ expression: res
     RuleViolation {
         kind: PreferBigintOverInt,
         span: Span {
-            start: 113,
-            len: Some(
-                38,
-            ),
+            start: 139,
+            len: None,
         },
         messages: [
             Note(

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_bigint_over_smallint__test_rules__create_table_bad.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_bigint_over_smallint__test_rules__create_table_bad.snap
@@ -6,10 +6,8 @@ expression: res
     RuleViolation {
         kind: PreferBigintOverSmallint,
         span: Span {
-            start: 0,
-            len: Some(
-                39,
-            ),
+            start: 26,
+            len: None,
         },
         messages: [
             Note(
@@ -23,10 +21,8 @@ expression: res
     RuleViolation {
         kind: PreferBigintOverSmallint,
         span: Span {
-            start: 40,
-            len: Some(
-                35,
-            ),
+            start: 66,
+            len: None,
         },
         messages: [
             Note(
@@ -40,10 +36,8 @@ expression: res
     RuleViolation {
         kind: PreferBigintOverSmallint,
         span: Span {
-            start: 76,
-            len: Some(
-                42,
-            ),
+            start: 102,
+            len: None,
         },
         messages: [
             Note(
@@ -57,10 +51,8 @@ expression: res
     RuleViolation {
         kind: PreferBigintOverSmallint,
         span: Span {
-            start: 119,
-            len: Some(
-                38,
-            ),
+            start: 145,
+            len: None,
         },
         messages: [
             Note(

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_identity__test_rules__prefer_identity_bad.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_identity__test_rules__prefer_identity_bad.snap
@@ -6,10 +6,8 @@ expression: res
     RuleViolation {
         kind: PreferIdentity,
         span: Span {
-            start: 0,
-            len: Some(
-                37,
-            ),
+            start: 26,
+            len: None,
         },
         messages: [
             Note(
@@ -23,10 +21,8 @@ expression: res
     RuleViolation {
         kind: PreferIdentity,
         span: Span {
-            start: 38,
-            len: Some(
-                38,
-            ),
+            start: 64,
+            len: None,
         },
         messages: [
             Note(
@@ -40,10 +36,8 @@ expression: res
     RuleViolation {
         kind: PreferIdentity,
         span: Span {
-            start: 77,
-            len: Some(
-                38,
-            ),
+            start: 103,
+            len: None,
         },
         messages: [
             Note(
@@ -57,10 +51,8 @@ expression: res
     RuleViolation {
         kind: PreferIdentity,
         span: Span {
-            start: 116,
-            len: Some(
-                38,
-            ),
+            start: 142,
+            len: None,
         },
         messages: [
             Note(
@@ -74,10 +66,8 @@ expression: res
     RuleViolation {
         kind: PreferIdentity,
         span: Span {
-            start: 155,
-            len: Some(
-                42,
-            ),
+            start: 181,
+            len: None,
         },
         messages: [
             Note(
@@ -91,10 +81,8 @@ expression: res
     RuleViolation {
         kind: PreferIdentity,
         span: Span {
-            start: 198,
-            len: Some(
-                40,
-            ),
+            start: 224,
+            len: None,
         },
         messages: [
             Note(

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_text_field__test_rules__adding_column_non_text.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_text_field__test_rules__adding_column_non_text.snap
@@ -6,10 +6,8 @@ expression: res
     RuleViolation {
         kind: PreferTextField,
         span: Span {
-            start: 7,
-            len: Some(
-                66,
-            ),
+            start: 43,
+            len: None,
         },
         messages: [
             Note(

--- a/linter/src/rules/snapshots/squawk_linter__rules__prefer_timestamptz__test_rules__alter_table.snap
+++ b/linter/src/rules/snapshots/squawk_linter__rules__prefer_timestamptz__test_rules__alter_table.snap
@@ -6,10 +6,8 @@ expression: res
     RuleViolation {
         kind: PreferTimestampTz,
         span: Span {
-            start: 0,
-            len: Some(
-                73,
-            ),
+            start: 48,
+            len: None,
         },
         messages: [
             Note(
@@ -23,10 +21,8 @@ expression: res
     RuleViolation {
         kind: PreferTimestampTz,
         span: Span {
-            start: 74,
-            len: Some(
-                94,
-            ),
+            start: 125,
+            len: None,
         },
         messages: [
             Note(

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -54,6 +54,16 @@ impl std::convert::From<&RawStmt> for Span {
     }
 }
 
+impl std::convert::From<&ColumnDef> for Span {
+    fn from(stmt: &ColumnDef) -> Self {
+        Self {
+            start: stmt.location,
+            // Use current line
+            len: None,
+        }
+    }
+}
+
 impl RawStmt {
     #[must_use]
     pub fn span(&self) -> Span {


### PR DESCRIPTION
## Summary

Fixed the display of lint errors for large DDL statements. Previously, when an error occurred, the output included the entire SQL statement, which could be very lengthy. The update now shows only the relevant line(s) with the issue.

## Problem

For large DDL files, any linting errors resulted in the full SQL being displayed in the output, making it difficult to identify the exact problematic lines in lengthy scripts.

**Example File**:
```sql
create table test_table (
    col1 varchar(255),
    col2 varchar(255),
    col3 varchar(255)
    --- other columns
);
```

**Previous Output**

Before the change, the output included the full SQL statement, repeated for each warning:
```
.tmp/big-int.sql:1:0: warning: prefer-text-field

   1 | create table test_table (
   2 |     col1 varchar(255),
   3 |     col2 varchar(255),
   4 |     col3 varchar(255)
   5 |     --- other columns
   6 | );

  note: Changing the size of a varchar field requires an ACCESS EXCLUSIVE lock.
  help: Use a text field with a check constraint.

.tmp/big-int.sql:1:0: warning: prefer-text-field

   1 | create table test_table (
   2 |     col1 varchar(255),
   3 |     col2 varchar(255),
   4 |     col3 varchar(255)
   5 |     --- other columns
   6 | );

  note: Changing the size of a varchar field requires an ACCESS EXCLUSIVE lock.
  help: Use a text field with a check constraint.

.tmp/big-int.sql:1:0: warning: prefer-text-field

   1 | create table test_table (
   2 |     col1 varchar(255),
   3 |     col2 varchar(255),
   4 |     col3 varchar(255)
   5 |     --- other columns
   6 | );

  note: Changing the size of a varchar field requires an ACCESS EXCLUSIVE lock.
  help: Use a text field with a check constraint.

find detailed examples and solutions for each rule at https://squawkhq.com/docs/rules
Found 3 issues in 1 file (checked 1 source file)

```

**New Output**

After the update, only the relevant lines are displayed, providing a cleaner and more focused output:

```
.tmp/big-int.sql:2:0: warning: prefer-text-field

   2 | col1 varchar(255),

  note: Changing the size of a varchar field requires an ACCESS EXCLUSIVE lock.
  help: Use a text field with a check constraint.

.tmp/big-int.sql:3:0: warning: prefer-text-field

   3 | col2 varchar(255),

  note: Changing the size of a varchar field requires an ACCESS EXCLUSIVE lock.
  help: Use a text field with a check constraint.

.tmp/big-int.sql:4:0: warning: prefer-text-field

   4 | col3 varchar(255)

  note: Changing the size of a varchar field requires an ACCESS EXCLUSIVE lock.
  help: Use a text field with a check constraint.

find detailed examples and solutions for each rule at https://squawkhq.com/docs/rules
Found 3 issues in 1 file (checked 1 source file)
```


## Additional Information

This improvement significantly reduces the noise in the output, making it easier to identify issues in large SQL files by only showing the lines related to the warning or error.

Let me know if you’d like any changes!