### PR TITLE
Add Docker usage example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ pip install squawk-cli
 https://github.com/sbdchd/squawk/releases
 ```
 
+### Without installation (Docker)
+
+You can run Squawk without installation using Docker. The official image is available on GitHub Container Registry.
+
+```shell
+# Assuming you want to check sql files in the current directory
+docker run --rm -v $(pwd):/data ghcr.io/sbdchd/squawk:latest *.sql
+```
+
 ## Usage
 
 ```shell


### PR DESCRIPTION
This commit updates the README to include an example of how to use the tool with Docker. It provides a clear command to run the container for checking SQL files without requiring installation.