### PR TITLE
parser: fix parsing string literal type cast

### DIFF
--- a/crates/squawk_parser/src/grammar.rs
+++ b/crates/squawk_parser/src/grammar.rs
@@ -1798,10 +1798,10 @@ fn name_ref_(p: &mut Parser<'_>) -> Option<CompletedMarker> {
         p.bump_any();
     }
     let cm = m.complete(p, NAME_REF);
-    // A path followed by a literal is a type cast so we insert a CAST_EXPR
+    // A path followed by a string is a type cast so we insert a CAST_EXPR
     // preceding it to wrap the previously parsed data.
     // e.g., `select numeric '12312'`
-    if !p.at(NULL_KW) && !p.at(DEFAULT_KW) && literal(p).is_some() {
+    if opt_string_literal(p).is_some() {
         if is_interval_cast {
             opt_interval_trailing(p);
         }

--- a/crates/squawk_parser/src/snapshots/squawk_parser__test__select_err.snap
+++ b/crates/squawk_parser/src/snapshots/squawk_parser__test__select_err.snap
@@ -192,6 +192,22 @@ SOURCE_FILE
               IDENT "c"
   SEMICOLON ";"
   WHITESPACE "\n\n"
+  COMMENT "-- type cast must use a string literal"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          NAME_REF
+            NUMERIC_KW "numeric"
+        WHITESPACE " "
+        TARGET
+          LITERAL
+            INT_NUMBER "1234"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
   COMMENT "-- trailing comma at EOF"
   WHITESPACE "\n"
   SELECT
@@ -215,4 +231,5 @@ ERROR@394: expected expression
 ERROR@395: expected expression
 ERROR@396: expected expression
 ERROR@397: expected expression
-ERROR@500: unexpected trailing comma
+ERROR@520: missing comma
+ERROR@561: unexpected trailing comma

--- a/crates/squawk_parser/test_data/err/select.sql
+++ b/crates/squawk_parser/test_data/err/select.sql
@@ -22,5 +22,8 @@ select f(a,,,,,);
 -- in can only be used with tuples / sub queries
 select 1 in c;
 
+-- type cast must use a string literal
+select numeric 1234;
+
 -- trailing comma at EOF
 select 1,


### PR DESCRIPTION
previously we'd parse:

```sql
select t 1;
```

as a type cast, but this sort of type cast is only valid when we're using a string literal!

Now we're more restrictive