### PR TITLE
linter: improve prefer-robust-stmts error messages

### DIFF
--- a/.vscode/extensions/squawk-dev/README.md
+++ b/.vscode/extensions/squawk-dev/README.md
@@ -2,6 +2,34 @@
 
 Extension to make developing squawk a little nicer.
 
+## Install
+
+```shell
+
+```
+
+1. install deps and build
+
+```sh
+cd .vscode/extensions/squawk-dev
+pnpm install
+pnpm run compile
+```
+
+2. enable extension in vscode
+
+In the command palette run:
+
+```
+Extensions: Show Recommended Extensions
+```
+
+You should then see the `recipeyak-dev` extension in the results.
+
+Press the `Install Workspace Extension` button.
+
+Done!
+
 ## Features
 
 ### Jump from snapshot to source file

--- a/.vscode/extensions/squawk-dev/README.md
+++ b/.vscode/extensions/squawk-dev/README.md
@@ -4,10 +4,6 @@ Extension to make developing squawk a little nicer.
 
 ## Install
 
-```shell
-
-```
-
 1. install deps and build
 
 ```sh

--- a/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__alter_column_set_not_null.snap
+++ b/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__alter_column_set_not_null.snap
@@ -5,8 +5,8 @@ expression: errors
 [
     Violation {
         code: PreferRobustStmts,
-        message: "Missing `IF EXISTS`, the migration can't be rerun if it fails part way through.",
-        text_range: 63..93,
+        message: "Missing transaction, the migration can't be rerun if it fails part way through.",
+        text_range: 54..81,
         help: None,
     },
 ]

--- a/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__alter_table_drop_column_err.snap
+++ b/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__alter_table_drop_column_err.snap
@@ -5,7 +5,7 @@ expression: errors
 [
     Violation {
         code: PreferRobustStmts,
-        message: "Missing `IF NOT EXISTS`, the migration can't be rerun if it fails part way through.",
+        message: "Missing `IF EXISTS`, the migration can't be rerun if it fails part way through.",
         text_range: 54..75,
         help: None,
     },

--- a/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__disable_row_level_security_err.snap
+++ b/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__disable_row_level_security_err.snap
@@ -5,7 +5,7 @@ expression: errors
 [
     Violation {
         code: PreferRobustStmts,
-        message: "Missing `IF NOT EXISTS`, the migration can't be rerun if it fails part way through.",
+        message: "Missing transaction, the migration can't be rerun if it fails part way through.",
         text_range: 63..89,
         help: None,
     },

--- a/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__double_add_after_drop_err.snap
+++ b/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__double_add_after_drop_err.snap
@@ -6,7 +6,7 @@ expression: errors
     Violation {
         code: PreferRobustStmts,
         message: "Missing `IF NOT EXISTS`, the migration can't be rerun if it fails part way through.",
-        text_range: 240..298,
+        text_range: 240..297,
         help: None,
     },
 ]

--- a/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__enable_row_level_security_err.snap
+++ b/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__enable_row_level_security_err.snap
@@ -5,7 +5,7 @@ expression: errors
 [
     Violation {
         code: PreferRobustStmts,
-        message: "Missing `IF NOT EXISTS`, the migration can't be rerun if it fails part way through.",
+        message: "Missing transaction, the migration can't be rerun if it fails part way through.",
         text_range: 63..88,
         help: None,
     },

--- a/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__enable_row_level_security_without_exists_check_err.snap
+++ b/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_robust_stmts__test__enable_row_level_security_without_exists_check_err.snap
@@ -5,7 +5,7 @@ expression: errors
 [
     Violation {
         code: PreferRobustStmts,
-        message: "Missing `IF NOT EXISTS`, the migration can't be rerun if it fails part way through.",
+        message: "Missing transaction, the migration can't be rerun if it fails part way through.",
         text_range: 53..78,
         help: None,
     },

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -246,7 +246,7 @@ function Editor({
     }
     const model = editorRef.current?.getModel()
     if (model != null) {
-      monaco.editor.setModelMarkers(model, "tea", markers)
+      monaco.editor.setModelMarkers(model, "squawk", markers)
     }
   }, [markers])
 
@@ -375,7 +375,7 @@ function useMarkers(text: string): Array<Marker> {
       // https://github.com/microsoft/monaco-editor/issues/1264
       // https://stackoverflow.com/questions/62362741/using-markdown-in-imarkerdata
       message: x.message,
-      source: "tea",
+      source: "squawk",
     }
   })
 }


### PR DESCRIPTION
also update internal vscode extension readme

and fix typo in playground linter source name `tea` instead of `squawk`