### PR TITLE
parser: fix parsing grant / revoke with schema specified names

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ cargo xtask new-rule 'prefer big serial'
 2. Run `s/update-version`
 
    ```bash
-   # update version in cli/Cargo.toml, package.json, flake.nix to 4.5.3
+   # update version in squawk/Cargo.toml, package.json, flake.nix to 4.5.3
    s/update-version 4.5.3
    ```
 

--- a/crates/squawk_parser/src/grammar.rs
+++ b/crates/squawk_parser/src/grammar.rs
@@ -6560,7 +6560,7 @@ fn alter_default_privileges_stmt(p: &mut Parser<'_>) -> CompletedMarker {
             p.bump(GRANT_KW);
             privileges(p);
             p.expect(ON_KW);
-            privilege_target(p);
+            privilege_target_type(p);
             p.expect(TO_KW);
             role(p);
             while !p.at(EOF) && p.eat(COMMA) {
@@ -6579,7 +6579,7 @@ fn alter_default_privileges_stmt(p: &mut Parser<'_>) -> CompletedMarker {
             }
             privileges(p);
             p.expect(ON_KW);
-            privilege_target(p);
+            privilege_target_type(p);
             p.expect(FROM_KW);
             role(p);
             while !p.at(EOF) && p.eat(COMMA) {
@@ -6594,7 +6594,7 @@ fn alter_default_privileges_stmt(p: &mut Parser<'_>) -> CompletedMarker {
     m.complete(p, ALTER_DEFAULT_PRIVILEGES_STMT)
 }
 
-fn privilege_target(p: &mut Parser<'_>) {
+fn privilege_target_type(p: &mut Parser<'_>) {
     match p.current() {
         TABLES_KW | FUNCTIONS_KW | ROUTINES_KW | SEQUENCES_KW | TYPES_KW | SCHEMAS_KW => {
             p.bump_any();
@@ -10052,90 +10052,7 @@ fn grant_stmt(p: &mut Parser<'_>) -> CompletedMarker {
     //       | ALL { FUNCTIONS | PROCEDURES | ROUTINES } IN SCHEMA schema_name [, ...] }
     // ON PARAMETER configuration_parameter [, ...]
     if p.eat(ON_KW) {
-        if p.eat(ALL_KW) {
-            match p.current() {
-                TABLES_KW | SEQUENCES_KW | FUNCTIONS_KW | PROCEDURES_KW | ROUTINES_KW => {
-                    p.bump_any();
-                    p.expect(IN_KW);
-                    p.expect(SCHEMA_KW);
-                    // schema_name [, ...]
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                _ => p.error("expected TABLE"),
-            }
-        } else {
-            match p.current() {
-                PARAMETER_KW => {
-                    p.bump(PARAMETER_KW);
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                FUNCTION_KW | PROCEDURE_KW | ROUTINE_KW => {
-                    p.bump_any();
-                    // function_name [ ( [ [ argmode ] [ arg_name ] arg_type [, ...] ] ) ] [, ...]
-                    path_name_ref(p);
-                    opt_param_list(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        // function_name [ ( [ [ argmode ] [ arg_name ] arg_type [, ...] ] ) ] [, ...]
-                        path_name_ref(p);
-                        opt_param_list(p);
-                    }
-                }
-                // TYPE type_name [, ...]
-                TYPE_KW => {
-                    p.bump(TYPE_KW);
-                    type_name(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        type_name(p);
-                    }
-                }
-                TABLE_KW | SEQUENCE_KW | DATABASE_KW | TABLESPACE_KW | SCHEMA_KW | LANGUAGE_KW
-                | DOMAIN_KW => {
-                    p.bump_any();
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                FOREIGN_KW => {
-                    p.bump(FOREIGN_KW);
-                    if p.eat(DATA_KW) {
-                        p.expect(WRAPPER_KW);
-                    } else {
-                        p.expect(SERVER_KW);
-                    }
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                LARGE_KW => {
-                    p.bump(LARGE_KW);
-                    p.expect(OBJECT_KW);
-                    if opt_numeric_literal(p).is_none() {
-                        p.error("expected large_object_oid")
-                    }
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        if opt_numeric_literal(p).is_none() {
-                            p.error("expected large_object_oid")
-                        }
-                    }
-                }
-                // table_name [, ...]
-                _ if p.at_ts(COL_LABEL_FIRST) => {
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                _ => (),
-            }
-        }
+        privilege_target(p);
     }
     // TO role_specification [, ...]
     p.expect(TO_KW);
@@ -10163,6 +10080,101 @@ fn grant_stmt(p: &mut Parser<'_>) -> CompletedMarker {
     }
     opt_granted_by(p);
     m.complete(p, GRANT_STMT)
+}
+
+fn privilege_target(p: &mut Parser<'_>) {
+    if p.eat(ALL_KW) {
+        match p.current() {
+            TABLES_KW | SEQUENCES_KW | FUNCTIONS_KW | PROCEDURES_KW | ROUTINES_KW => {
+                p.bump_any();
+                p.expect(IN_KW);
+                p.expect(SCHEMA_KW);
+                // schema_name [, ...]
+                name_ref(p);
+                while !p.at(EOF) && p.eat(COMMA) {
+                    name_ref(p);
+                }
+            }
+            _ => p.error("expected TABLE"),
+        }
+    } else {
+        match p.current() {
+            PARAMETER_KW => {
+                p.bump(PARAMETER_KW);
+                path_name_ref(p);
+                while !p.at(EOF) && p.eat(COMMA) {
+                    path_name_ref(p);
+                }
+            }
+            FUNCTION_KW | PROCEDURE_KW | ROUTINE_KW => {
+                p.bump_any();
+                // function_name [ ( [ [ argmode ] [ arg_name ] arg_type [, ...] ] ) ] [, ...]
+                path_name_ref(p);
+                opt_param_list(p);
+                while !p.at(EOF) && p.eat(COMMA) {
+                    // function_name [ ( [ [ argmode ] [ arg_name ] arg_type [, ...] ] ) ] [, ...]
+                    path_name_ref(p);
+                    opt_param_list(p);
+                }
+            }
+            // TYPE type_name [, ...]
+            TYPE_KW => {
+                p.bump(TYPE_KW);
+                type_name(p);
+                while !p.at(EOF) && p.eat(COMMA) {
+                    type_name(p);
+                }
+            }
+            // no schema allowed for the name
+            DATABASE_KW | TABLESPACE_KW | SCHEMA_KW | LANGUAGE_KW => {
+                p.bump_any();
+                name_ref(p);
+                while !p.at(EOF) && p.eat(COMMA) {
+                    name_ref(p);
+                }
+            }
+            // these allow schema
+            TABLE_KW | SEQUENCE_KW | DOMAIN_KW => {
+                p.bump_any();
+                path_name_ref(p);
+                while !p.at(EOF) && p.eat(COMMA) {
+                    path_name_ref(p);
+                }
+            }
+            FOREIGN_KW => {
+                p.bump(FOREIGN_KW);
+                if p.eat(DATA_KW) {
+                    p.expect(WRAPPER_KW);
+                } else {
+                    p.expect(SERVER_KW);
+                }
+                name_ref(p);
+                while !p.at(EOF) && p.eat(COMMA) {
+                    name_ref(p);
+                }
+            }
+            LARGE_KW => {
+                p.bump(LARGE_KW);
+                p.expect(OBJECT_KW);
+                if opt_numeric_literal(p).is_none() {
+                    p.error("expected large_object_oid")
+                }
+                while !p.at(EOF) && p.eat(COMMA) {
+                    if opt_numeric_literal(p).is_none() {
+                        p.error("expected large_object_oid")
+                    }
+                }
+            }
+            // table_name [, ...]
+            _ if p.at_ts(COL_LABEL_FIRST) => {
+                path_name_ref(p);
+                while !p.at(EOF) && p.eat(COMMA) {
+                    path_name_ref(p);
+                }
+            }
+            _ => (),
+        }
+    }
 }
 
 // [ GRANTED BY role_specification ]
@@ -10214,88 +10226,7 @@ fn revoke_stmt(p: &mut Parser<'_>) -> CompletedMarker {
     //       | ALL { FUNCTIONS | PROCEDURES | ROUTINES } IN SCHEMA schema_name [, ...] }
     // ON PARAMETER configuration_parameter [, ...]
     if p.eat(ON_KW) {
-        if p.eat(ALL_KW) {
-            match p.current() {
-                TABLES_KW | SEQUENCES_KW | FUNCTIONS_KW | PROCEDURES_KW | ROUTINES_KW => {
-                    p.bump_any();
-                    p.expect(IN_KW);
-                    p.expect(SCHEMA_KW);
-                    // schema_name [, ...]
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                _ => p.error("expected TABLE"),
-            }
-        } else {
-            match p.current() {
-                PARAMETER_KW => {
-                    p.bump(PARAMETER_KW);
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                FUNCTION_KW | PROCEDURE_KW | ROUTINE_KW => {
-                    p.bump_any();
-                    path_name_ref(p);
-                    opt_param_list(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        path_name_ref(p);
-                        opt_param_list(p);
-                    }
-                }
-                // TYPE type_name [, ...]
-                TYPE_KW => {
-                    p.bump(TYPE_KW);
-                    type_name(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        type_name(p);
-                    }
-                }
-                TABLE_KW | SEQUENCE_KW | DATABASE_KW | TABLESPACE_KW | SCHEMA_KW | LANGUAGE_KW
-                | DOMAIN_KW => {
-                    p.bump_any();
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                FOREIGN_KW => {
-                    p.bump(FOREIGN_KW);
-                    if p.eat(DATA_KW) {
-                        p.expect(WRAPPER_KW);
-                    } else {
-                        p.expect(SERVER_KW);
-                    }
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                LARGE_KW => {
-                    p.bump(LARGE_KW);
-                    p.expect(OBJECT_KW);
-                    if opt_numeric_literal(p).is_none() {
-                        p.error("expected large_object_oid")
-                    }
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        if opt_numeric_literal(p).is_none() {
-                            p.error("expected large_object_oid")
-                        }
-                    }
-                }
-                // table_name [, ...]
-                _ if p.at_ts(COL_LABEL_FIRST) => {
-                    name_ref(p);
-                    while !p.at(EOF) && p.eat(COMMA) {
-                        name_ref(p);
-                    }
-                }
-                _ => (),
-            }
-        }
+        privilege_target(p);
     }
     // FROM role_specification [, ...]
     p.expect(FROM_KW);

--- a/crates/squawk_parser/src/snapshots/squawk_parser__test__grant_ok.snap
+++ b/crates/squawk_parser/src/snapshots/squawk_parser__test__grant_ok.snap
@@ -33,8 +33,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -54,16 +56,22 @@ SOURCE_FILE
     WHITESPACE " "
     TABLE_KW "table"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "b"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "b"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "c"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "c"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -91,11 +99,39 @@ SOURCE_FILE
     ALL_KW "all"
     WHITESPACE " "
     PRIVILEGES_KW "privileges"
+    WHITESPACE " \n  "
+    ON_KW "on"
+    WHITESPACE " "
+    TABLE_KW "table"
+    WHITESPACE " "
+    PATH
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "s"
+      DOT "."
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
+    WHITESPACE "\n  "
+    TO_KW "to"
+    WHITESPACE " "
+    CURRENT_USER_KW "current_user"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
+  GRANT_STMT
+    GRANT_KW "grant"
+    WHITESPACE " "
+    ALL_KW "all"
+    WHITESPACE " "
+    PRIVILEGES_KW "privileges"
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -164,8 +200,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     TO_KW "to"
     WHITESPACE " "
@@ -195,8 +233,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     TO_KW "to"
     WHITESPACE " "
@@ -226,8 +266,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     TO_KW "to"
     WHITESPACE " "
@@ -257,8 +299,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     TO_KW "to"
     WHITESPACE " "
@@ -280,8 +324,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     TO_KW "to"
     WHITESPACE " "
@@ -301,8 +347,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     TO_KW "to"
     WHITESPACE " "
@@ -320,8 +368,34 @@ SOURCE_FILE
     WHITESPACE " "
     SEQUENCE_KW "sequence"
     WHITESPACE " "
-    NAME_REF
-      IDENT "s"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "s"
+    WHITESPACE "\n  "
+    TO_KW "to"
+    WHITESPACE " "
+    CURRENT_USER_KW "current_user"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
+  GRANT_STMT
+    GRANT_KW "grant"
+    WHITESPACE " "
+    SELECT_KW "select"
+    WHITESPACE " "
+    ON_KW "on"
+    WHITESPACE " "
+    SEQUENCE_KW "sequence"
+    WHITESPACE " "
+    PATH
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "public"
+      DOT "."
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "s"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -337,16 +411,22 @@ SOURCE_FILE
     WHITESPACE " "
     SEQUENCE_KW "sequence"
     WHITESPACE " "
-    NAME_REF
-      IDENT "a"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "a"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "b"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "b"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "c"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "c"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -362,8 +442,10 @@ SOURCE_FILE
     WHITESPACE " "
     SEQUENCE_KW "sequence"
     WHITESPACE " "
-    NAME_REF
-      IDENT "x"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "x"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -513,16 +595,22 @@ SOURCE_FILE
     WHITESPACE " "
     DOMAIN_KW "domain"
     WHITESPACE " "
-    NAME_REF
-      IDENT "a"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "a"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "b"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "b"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "c"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "c"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -546,8 +634,36 @@ SOURCE_FILE
     WHITESPACE " "
     DOMAIN_KW "domain"
     WHITESPACE " "
-    NAME_REF
-      IDENT "d"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "d"
+    WHITESPACE "\n  "
+    TO_KW "to"
+    WHITESPACE " "
+    CURRENT_USER_KW "current_user"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
+  GRANT_STMT
+    GRANT_KW "grant"
+    WHITESPACE " "
+    ALL_KW "all"
+    WHITESPACE " "
+    PRIVILEGES_KW "privileges"
+    WHITESPACE "\n  "
+    ON_KW "on"
+    WHITESPACE " "
+    DOMAIN_KW "domain"
+    WHITESPACE " "
+    PATH
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "s"
+      DOT "."
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "d"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -1091,16 +1207,22 @@ SOURCE_FILE
     WHITESPACE " "
     PARAMETER_KW "parameter"
     WHITESPACE " "
-    NAME_REF
-      IDENT "foo"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "foo"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "bar"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "bar"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "buzz"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "buzz"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -1118,8 +1240,10 @@ SOURCE_FILE
     WHITESPACE " "
     PARAMETER_KW "parameter"
     WHITESPACE " "
-    NAME_REF
-      BEGIN_KW "begin"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          BEGIN_KW "begin"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -1135,8 +1259,10 @@ SOURCE_FILE
     WHITESPACE " "
     PARAMETER_KW "parameter"
     WHITESPACE " "
-    NAME_REF
-      BEGIN_KW "begin"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          BEGIN_KW "begin"
     WHITESPACE "\n  "
     TO_KW "to"
     WHITESPACE " "
@@ -1377,6 +1503,31 @@ SOURCE_FILE
     CURRENT_USER_KW "current_user"
   SEMICOLON ";"
   WHITESPACE "\n\n"
+  GRANT_STMT
+    GRANT_KW "grant"
+    WHITESPACE " "
+    ALL_KW "all"
+    WHITESPACE " \n  "
+    ON_KW "on"
+    WHITESPACE " "
+    TYPE_KW "type"
+    WHITESPACE " "
+    PATH_TYPE
+      PATH
+        PATH
+          PATH_SEGMENT
+            NAME_REF
+              IDENT "s"
+        DOT "."
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "t"
+    WHITESPACE "\n  "
+    TO_KW "to"
+    WHITESPACE " "
+    CURRENT_USER_KW "current_user"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
   COMMENT "-- option"
   WHITESPACE "\n"
   GRANT_STMT
@@ -1482,4 +1633,4 @@ SOURCE_FILE
     WHITESPACE " "
     CURRENT_USER_KW "current_user"
   SEMICOLON ";"
-  WHITESPACE "\n\n"
+  WHITESPACE "\n"

--- a/crates/squawk_parser/src/snapshots/squawk_parser__test__revoke_ok.snap
+++ b/crates/squawk_parser/src/snapshots/squawk_parser__test__revoke_ok.snap
@@ -33,8 +33,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -60,16 +62,65 @@ SOURCE_FILE
     WHITESPACE " "
     TABLE_KW "table"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "b"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "b"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "c"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "c"
+    WHITESPACE "\n  "
+    FROM_KW "from"
+    WHITESPACE " "
+    CURRENT_USER_KW "current_user"
+    COMMA ","
+    WHITESPACE " "
+    CURRENT_ROLE_KW "current_role"
+    WHITESPACE "\n  "
+    GRANTED_KW "granted"
+    WHITESPACE " "
+    BY_KW "by"
+    WHITESPACE " "
+    IDENT "public"
+    WHITESPACE "\n  "
+    CASCADE_KW "cascade"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
+  REVOKE_STMT
+    REVOKE_KW "revoke"
+    WHITESPACE " "
+    GRANT_KW "grant"
+    WHITESPACE " "
+    OPTION_KW "option"
+    WHITESPACE " "
+    FOR_KW "for"
+    WHITESPACE " \n  "
+    ALL_KW "all"
+    WHITESPACE " "
+    PRIVILEGES_KW "privileges"
+    WHITESPACE " \n  "
+    ON_KW "on"
+    WHITESPACE " "
+    TABLE_KW "table"
+    WHITESPACE " "
+    PATH
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "s"
+      DOT "."
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -102,8 +153,51 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
+    WHITESPACE "\n  "
+    FROM_KW "from"
+    WHITESPACE " "
+    CURRENT_USER_KW "current_user"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
+  REVOKE_STMT
+    REVOKE_KW "revoke"
+    WHITESPACE " "
+    GRANT_KW "grant"
+    WHITESPACE " "
+    OPTION_KW "option"
+    WHITESPACE " "
+    FOR_KW "for"
+    WHITESPACE " "
+    ALL_KW "all"
+    WHITESPACE " "
+    PRIVILEGES_KW "privileges"
+    WHITESPACE "\n  "
+    ON_KW "on"
+    WHITESPACE " "
+    PATH
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "s"
+      DOT "."
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
+    COMMA ","
+    WHITESPACE " "
+    PATH
+      PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "b"
+      DOT "."
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -174,8 +268,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -205,8 +301,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -236,8 +334,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -267,8 +367,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -290,8 +392,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -311,8 +415,10 @@ SOURCE_FILE
     WHITESPACE "\n  "
     ON_KW "on"
     WHITESPACE " "
-    NAME_REF
-      IDENT "t"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "t"
     WHITESPACE " \n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -330,8 +436,10 @@ SOURCE_FILE
     WHITESPACE " "
     SEQUENCE_KW "sequence"
     WHITESPACE " "
-    NAME_REF
-      IDENT "s"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "s"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -347,16 +455,22 @@ SOURCE_FILE
     WHITESPACE " "
     SEQUENCE_KW "sequence"
     WHITESPACE " "
-    NAME_REF
-      IDENT "a"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "a"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "b"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "b"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "c"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "c"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -372,8 +486,10 @@ SOURCE_FILE
     WHITESPACE " "
     SEQUENCE_KW "sequence"
     WHITESPACE " "
-    NAME_REF
-      IDENT "x"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "x"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -529,16 +645,22 @@ SOURCE_FILE
     WHITESPACE " "
     DOMAIN_KW "domain"
     WHITESPACE " "
-    NAME_REF
-      IDENT "a"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "a"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "b"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "b"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "c"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "c"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -556,8 +678,10 @@ SOURCE_FILE
     WHITESPACE " "
     DOMAIN_KW "domain"
     WHITESPACE " "
-    NAME_REF
-      IDENT "d"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "d"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -1101,16 +1225,22 @@ SOURCE_FILE
     WHITESPACE " "
     PARAMETER_KW "parameter"
     WHITESPACE " "
-    NAME_REF
-      IDENT "foo"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "foo"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "bar"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "bar"
     COMMA ","
     WHITESPACE " "
-    NAME_REF
-      IDENT "buzz"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          IDENT "buzz"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -1128,8 +1258,10 @@ SOURCE_FILE
     WHITESPACE " "
     PARAMETER_KW "parameter"
     WHITESPACE " "
-    NAME_REF
-      BEGIN_KW "begin"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          BEGIN_KW "begin"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -1145,8 +1277,10 @@ SOURCE_FILE
     WHITESPACE " "
     PARAMETER_KW "parameter"
     WHITESPACE " "
-    NAME_REF
-      BEGIN_KW "begin"
+    PATH
+      PATH_SEGMENT
+        NAME_REF
+          BEGIN_KW "begin"
     WHITESPACE "\n  "
     FROM_KW "from"
     WHITESPACE " "
@@ -1364,6 +1498,31 @@ SOURCE_FILE
     WHITESPACE " "
     PATH_TYPE
       PATH
+        PATH_SEGMENT
+          NAME_REF
+            IDENT "t"
+    WHITESPACE "\n  "
+    FROM_KW "from"
+    WHITESPACE " "
+    CURRENT_USER_KW "current_user"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
+  REVOKE_STMT
+    REVOKE_KW "revoke"
+    WHITESPACE " "
+    ALL_KW "all"
+    WHITESPACE " \n  "
+    ON_KW "on"
+    WHITESPACE " "
+    TYPE_KW "type"
+    WHITESPACE " "
+    PATH_TYPE
+      PATH
+        PATH
+          PATH_SEGMENT
+            NAME_REF
+              IDENT "s"
+        DOT "."
         PATH_SEGMENT
           NAME_REF
             IDENT "t"

--- a/crates/squawk_parser/test_data/ok/grant.sql
+++ b/crates/squawk_parser/test_data/ok/grant.sql
@@ -10,6 +10,10 @@ grant all privileges
   with grant option
   granted by public;
 
+grant all privileges 
+  on table s.t
+  to current_user;
+
 grant all privileges
   on t
   to current_user;
@@ -49,6 +53,9 @@ grant all(a)
 grant select on sequence s
   to current_user;
 
+grant select on sequence public.s
+  to current_user;
+
 grant usage on sequence a, b, c
   to current_user;
 
@@ -83,6 +90,10 @@ grant usage
 
 grant all privileges
   on domain d
+  to current_user;
+
+grant all privileges
+  on domain s.d
   to current_user;
 
 -- foreign_data
@@ -209,6 +220,10 @@ grant all
   on type t
   to current_user;
 
+grant all 
+  on type s.t
+  to current_user;
+
 -- option
 grant public
   to current_user
@@ -232,4 +247,3 @@ grant public, t(a, b)
 
 grant public
   to current_user;
-

--- a/crates/squawk_parser/test_data/ok/revoke.sql
+++ b/crates/squawk_parser/test_data/ok/revoke.sql
@@ -11,8 +11,19 @@ revoke grant option for
   granted by public
   cascade;
 
+revoke grant option for 
+  all privileges 
+  on table s.t
+  from current_user, current_role
+  granted by public
+  cascade;
+
 revoke grant option for all privileges
   on t
+  from current_user;
+
+revoke grant option for all privileges
+  on s.t, b.t
   from current_user;
 
 -- on_all_tables
@@ -202,6 +213,10 @@ revoke usage
 
 revoke all 
   on type t
+  from current_user;
+
+revoke all 
+  on type s.t
   from current_user;
 
 -- option


### PR DESCRIPTION
previously

```sql
GRANT ALL ON SEQUENCE public.s TO u;
```

wouldn't parse

managed to de-dupe some logic between revoke & grant

rel: https://github.com/sbdchd/squawk/issues/466