### PR TITLE
playground: fix ci auto deploy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -289,6 +289,7 @@ jobs:
         with:
           publish-dir: "playground/dist"
           production-branch: main
+          production-deploy: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"
           fails-without-credentials: true


### PR DESCRIPTION
missing the `production-deploy` so we were only making preview deploys :/ 