### PR TITLE
Check if existing comment contains "Squawk Report" header.

### DIFF
--- a/crates/squawk/src/github.rs
+++ b/crates/squawk/src/github.rs
@@ -66,6 +66,8 @@ fn create_gh_app(
     )
 }
 
+const COMMENT_HEADER: &str = "# Squawk Report";
+
 pub fn check_and_comment_on_pr(
     cmd: Command,
     cfg: &Config,
@@ -130,6 +132,7 @@ pub fn check_and_comment_on_pr(
         &github_repo_name,
         github_pr_number,
         &comment_body,
+        COMMENT_HEADER,
     )?;
 
     let violations: usize = file_results.iter().map(|f| f.violations.len()).sum();
@@ -149,7 +152,7 @@ fn get_comment_body(files: &[CheckReport], version: &str) -> String {
 
     format!(
         r"
-# Squawk Report
+{COMMENT_HEADER}
 
 ### **{violations_emoji} {violation_count}** violations across **{file_count}** file(s)
 

--- a/crates/squawk_github/src/lib.rs
+++ b/crates/squawk_github/src/lib.rs
@@ -79,6 +79,12 @@ pub fn comment_on_pr(
     match comments.iter().find(|x| {
         x.user.r#type == "Bot"
             && x.user.login == bot_name
+            // NOTE: We filter comments by their contents so we don't accidentally
+            // overwrite a comment made by some other tool. This happens often in
+            // GitHub repos that reuse the default GHA bot for all linters.
+            //
+            // This only works if `existing_comment_text_includes` is a "stable"
+            // piece of text included in all comments made by squawk!
             && x.body.contains(existing_comment_text_includes)
     }) {
         Some(prev_comment) => {

--- a/crates/squawk_github/src/lib.rs
+++ b/crates/squawk_github/src/lib.rs
@@ -69,16 +69,18 @@ pub fn comment_on_pr(
     repo: &str,
     issue: i64,
     body: &str,
+    existing_comment_text_includes: &str,
 ) -> Result<(), GithubError> {
     let comments = gh.list_issue_comments(owner, repo, issue)?;
 
     let bot_name = gh.app_slug();
 
     info!("checking for existing comment");
-    match comments
-        .iter()
-        .find(|x| x.user.r#type == "Bot" && x.user.login == bot_name)
-    {
+    match comments.iter().find(|x| {
+        x.user.r#type == "Bot"
+            && x.user.login == bot_name
+            && x.body.contains(existing_comment_text_includes)
+    }) {
         Some(prev_comment) => {
             info!("updating comment");
             gh.update_issue_comment(owner, repo, prev_comment.id, body)


### PR DESCRIPTION
Closes #476

When searching for an existing comment to overwrite, check the body of each comment to see if it includes the expected header. This should prevent Squawk from accidentally overwriting comments generated by other GHAs.