### PR TITLE
syntax: rename top level Item enum to Stmt

### DIFF
--- a/crates/squawk_linter/src/rules/adding_field_with_default.rs
+++ b/crates/squawk_linter/src/rules/adding_field_with_default.rs
@@ -58,7 +58,7 @@ pub(crate) fn adding_field_with_default(ctx: &mut Linter, parse: &Parse<SourceFi
     let file = parse.tree();
     // TODO: use match_ast! like in #api_walkthrough
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 if let ast::AlterTableAction::AddColumn(add_column) = action {
                     for constraint in add_column.constraints() {

--- a/crates/squawk_linter/src/rules/adding_foreign_key_constraint.rs
+++ b/crates/squawk_linter/src/rules/adding_foreign_key_constraint.rs
@@ -11,7 +11,7 @@ pub(crate) fn adding_foreign_key_constraint(ctx: &mut Linter, parse: &Parse<Sour
     let file = parse.tree();
     // TODO: use match_ast! like in #api_walkthrough
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 match action {
                     ast::AlterTableAction::AddConstraint(add_constraint) => {

--- a/crates/squawk_linter/src/rules/adding_not_null_field.rs
+++ b/crates/squawk_linter/src/rules/adding_not_null_field.rs
@@ -11,7 +11,7 @@ pub(crate) fn adding_not_null_field(ctx: &mut Linter, parse: &Parse<SourceFile>)
     }
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 if let ast::AlterTableAction::AlterColumn(alter_column) = action {
                     let Some(option) = alter_column.option() else {

--- a/crates/squawk_linter/src/rules/adding_primary_key_constraint.rs
+++ b/crates/squawk_linter/src/rules/adding_primary_key_constraint.rs
@@ -10,7 +10,7 @@ pub(crate) fn adding_primary_key_constraint(ctx: &mut Linter, parse: &Parse<Sour
     let help = "Add the `PRIMARY KEY` constraint `USING` an index.";
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 match action {
                     ast::AlterTableAction::AddConstraint(add_constraint) => {

--- a/crates/squawk_linter/src/rules/adding_required_field.rs
+++ b/crates/squawk_linter/src/rules/adding_required_field.rs
@@ -8,7 +8,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn adding_required_field(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 if let ast::AlterTableAction::AddColumn(add_column) = action {
                     if has_generated_constrait(add_column.constraints()) {

--- a/crates/squawk_linter/src/rules/ban_alter_domain_with_add_constraint.rs
+++ b/crates/squawk_linter/src/rules/ban_alter_domain_with_add_constraint.rs
@@ -8,7 +8,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn ban_alter_domain_with_add_constraint(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::AlterDomain(alter_domain) = item {
+        if let ast::Stmt::AlterDomain(alter_domain) = item {
             let actions = alter_domain.actions();
             for action in actions {
                 if let ast::AlterDomainAction::AddConstraint(add_constraint) = action {

--- a/crates/squawk_linter/src/rules/ban_concurrent_index_creation_in_transaction.rs
+++ b/crates/squawk_linter/src/rules/ban_concurrent_index_creation_in_transaction.rs
@@ -16,13 +16,13 @@ pub(crate) fn ban_concurrent_index_creation_in_transaction(
     for item in file.items() {
         stmt_count += 1;
         match item {
-            ast::Item::Begin(_) => {
+            ast::Stmt::Begin(_) => {
                 in_transaction = true;
             }
-            ast::Item::Commit(_) => {
+            ast::Stmt::Commit(_) => {
                 in_transaction = false;
             }
-            ast::Item::CreateIndex(create_index) => {
+            ast::Stmt::CreateIndex(create_index) => {
                 if in_transaction {
                     if let Some(concurrently) = create_index.concurrently_token() {
                         errors.push(Violation::new(

--- a/crates/squawk_linter/src/rules/ban_create_domain_with_constraint.rs
+++ b/crates/squawk_linter/src/rules/ban_create_domain_with_constraint.rs
@@ -9,7 +9,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn ban_create_domain_with_constraint(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::CreateDomain(domain) = item {
+        if let ast::Stmt::CreateDomain(domain) = item {
             let range =
                 domain
                     .constraints()

--- a/crates/squawk_linter/src/rules/ban_drop_column.rs
+++ b/crates/squawk_linter/src/rules/ban_drop_column.rs
@@ -8,7 +8,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn ban_drop_column(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 if let ast::AlterTableAction::DropColumn(drop_column) = action {
                     ctx.report(Violation::new(

--- a/crates/squawk_linter/src/rules/ban_drop_database.rs
+++ b/crates/squawk_linter/src/rules/ban_drop_database.rs
@@ -9,7 +9,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn ban_drop_database(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::DropDatabase(drop_database) = item {
+        if let ast::Stmt::DropDatabase(drop_database) = item {
             ctx.report(Violation::new(
                 Rule::BanDropDatabase,
                 "Dropping a database may break existing clients.".into(),

--- a/crates/squawk_linter/src/rules/ban_drop_not_null.rs
+++ b/crates/squawk_linter/src/rules/ban_drop_not_null.rs
@@ -8,7 +8,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn ban_drop_not_null(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 if let ast::AlterTableAction::AlterColumn(alter_column) = action {
                     if let Some(ast::AlterColumnOption::DropNotNull(drop_not_null)) =

--- a/crates/squawk_linter/src/rules/ban_drop_table.rs
+++ b/crates/squawk_linter/src/rules/ban_drop_table.rs
@@ -8,7 +8,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn ban_drop_table(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::DropTable(drop_table) = item {
+        if let ast::Stmt::DropTable(drop_table) = item {
             ctx.report(Violation::new(
                 Rule::BanDropTable,
                 "Dropping a table may break existing clients.".into(),

--- a/crates/squawk_linter/src/rules/ban_truncate_cascade.rs
+++ b/crates/squawk_linter/src/rules/ban_truncate_cascade.rs
@@ -9,7 +9,7 @@ pub(crate) fn ban_truncate_cascade(ctx: &mut Linter, parse: &Parse<SourceFile>) 
     let file = parse.tree();
     for item in file.items() {
         match item {
-            ast::Item::Truncate(truncate) => {
+            ast::Stmt::Truncate(truncate) => {
                 if let Some(cascade) = truncate.cascade_token() {
                     // TODO: if we had knowledge about the entire schema, we
                     // could be more precise here and actually navigate the

--- a/crates/squawk_linter/src/rules/changing_column_type.rs
+++ b/crates/squawk_linter/src/rules/changing_column_type.rs
@@ -8,7 +8,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn changing_column_type(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 if let ast::AlterTableAction::AlterColumn(alter_column) = action {
                     if let Some(ast::AlterColumnOption::SetType(set_type)) = alter_column.option() {

--- a/crates/squawk_linter/src/rules/constraint_missing_not_valid.rs
+++ b/crates/squawk_linter/src/rules/constraint_missing_not_valid.rs
@@ -15,13 +15,13 @@ pub fn tables_created_in_transaction(
     let mut inside_transaction = assume_in_transaction;
     for item in file.items() {
         match item {
-            ast::Item::Begin(_) => {
+            ast::Stmt::Begin(_) => {
                 inside_transaction = true;
             }
-            ast::Item::Commit(_) => {
+            ast::Stmt::Commit(_) => {
                 inside_transaction = false;
             }
-            ast::Item::CreateTable(create_table) if inside_transaction => {
+            ast::Stmt::CreateTable(create_table) if inside_transaction => {
                 let Some(table_name) = create_table
                     .path()
                     .and_then(|x| x.segment())
@@ -46,7 +46,7 @@ fn not_valid_validate_in_transaction(
     let mut not_valid_names: HashSet<String> = HashSet::new();
     for item in file.items() {
         match item {
-            ast::Item::AlterTable(alter_table) => {
+            ast::Stmt::AlterTable(alter_table) => {
                 for action in alter_table.actions() {
                     match action {
                         ast::AlterTableAction::ValidateConstraint(validate_constraint) => {
@@ -81,13 +81,13 @@ fn not_valid_validate_in_transaction(
                     }
                 }
             }
-            ast::Item::Begin(_) => {
+            ast::Stmt::Begin(_) => {
                 if !inside_transaction {
                     not_valid_names.clear();
                 }
                 inside_transaction = true;
             }
-            ast::Item::Commit(_) => {
+            ast::Stmt::Commit(_) => {
                 inside_transaction = false;
             }
             _ => (),
@@ -105,7 +105,7 @@ pub(crate) fn constraint_missing_not_valid(ctx: &mut Linter, parse: &Parse<Sourc
     let tables_created = tables_created_in_transaction(assume_in_transaction, &file);
 
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             let Some(table_name) = alter_table
                 .path()
                 .and_then(|x| x.segment())

--- a/crates/squawk_linter/src/rules/disallow_unique_constraint.rs
+++ b/crates/squawk_linter/src/rules/disallow_unique_constraint.rs
@@ -13,7 +13,7 @@ pub(crate) fn disallow_unique_constraint(ctx: &mut Linter, parse: &Parse<SourceF
     let file = parse.tree();
     let tables_created = tables_created_in_transaction(ctx.settings.assume_in_transaction, &file);
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             let Some(table_name) = alter_table
                 .path()
                 .and_then(|x| x.segment())

--- a/crates/squawk_linter/src/rules/prefer_robust_stmts.rs
+++ b/crates/squawk_linter/src/rules/prefer_robust_stmts.rs
@@ -38,13 +38,13 @@ pub(crate) fn prefer_robust_stmts(ctx: &mut Linter, parse: &Parse<SourceFile>) {
 
     for item in file.items() {
         match item {
-            ast::Item::Begin(_) => {
+            ast::Stmt::Begin(_) => {
                 inside_transaction = true;
             }
-            ast::Item::Commit(_) => {
+            ast::Stmt::Commit(_) => {
                 inside_transaction = false;
             }
-            ast::Item::AlterTable(alter_table) => {
+            ast::Stmt::AlterTable(alter_table) => {
                 for action in alter_table.actions() {
                     let message_type = match &action {
                         ast::AlterTableAction::DropConstraint(drop_constraint) => {
@@ -122,7 +122,7 @@ pub(crate) fn prefer_robust_stmts(ctx: &mut Linter, parse: &Parse<SourceFile>) {
                     ));
                 }
             }
-            ast::Item::CreateIndex(create_index)
+            ast::Stmt::CreateIndex(create_index)
                 if create_index.if_not_exists().is_none()
                     && (create_index.concurrently_token().is_some() || !inside_transaction) =>
             {
@@ -133,7 +133,7 @@ pub(crate) fn prefer_robust_stmts(ctx: &mut Linter, parse: &Parse<SourceFile>) {
                     "Use an explicit name for a concurrently created index".to_string(),
                 ));
             }
-            ast::Item::CreateTable(create_table)
+            ast::Stmt::CreateTable(create_table)
                 if create_table.if_not_exists().is_none() && !inside_transaction =>
             {
                 ctx.report(Violation::new(
@@ -143,7 +143,7 @@ pub(crate) fn prefer_robust_stmts(ctx: &mut Linter, parse: &Parse<SourceFile>) {
                     None,
                 ));
             }
-            ast::Item::DropIndex(drop_index)
+            ast::Stmt::DropIndex(drop_index)
                 if drop_index.if_exists().is_none() && !inside_transaction =>
             {
                 ctx.report(Violation::new(
@@ -153,7 +153,7 @@ pub(crate) fn prefer_robust_stmts(ctx: &mut Linter, parse: &Parse<SourceFile>) {
                     None,
                 ));
             }
-            ast::Item::DropTable(drop_table)
+            ast::Stmt::DropTable(drop_table)
                 if drop_table.if_exists().is_none() && !inside_transaction =>
             {
                 ctx.report(Violation::new(
@@ -163,7 +163,7 @@ pub(crate) fn prefer_robust_stmts(ctx: &mut Linter, parse: &Parse<SourceFile>) {
                     None,
                 ));
             }
-            ast::Item::DropType(drop_type)
+            ast::Stmt::DropType(drop_type)
                 if drop_type.if_exists().is_none() && !inside_transaction =>
             {
                 ctx.report(Violation::new(

--- a/crates/squawk_linter/src/rules/renaming_column.rs
+++ b/crates/squawk_linter/src/rules/renaming_column.rs
@@ -8,7 +8,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn renaming_column(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 if let ast::AlterTableAction::RenameColumn(rename_column) = action {
                     ctx.report(Violation::new(

--- a/crates/squawk_linter/src/rules/renaming_table.rs
+++ b/crates/squawk_linter/src/rules/renaming_table.rs
@@ -8,7 +8,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn renaming_table(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::AlterTable(alter_table) = item {
+        if let ast::Stmt::AlterTable(alter_table) = item {
             for action in alter_table.actions() {
                 if let ast::AlterTableAction::RenameTable(rename_table) = action {
                     ctx.report(Violation::new(

--- a/crates/squawk_linter/src/rules/require_concurrent_index_creation.rs
+++ b/crates/squawk_linter/src/rules/require_concurrent_index_creation.rs
@@ -11,7 +11,7 @@ pub(crate) fn require_concurrent_index_creation(ctx: &mut Linter, parse: &Parse<
     let file = parse.tree();
     let tables_created = tables_created_in_transaction(ctx.settings.assume_in_transaction, &file);
     for item in file.items() {
-        if let ast::Item::CreateIndex(create_index) = item {
+        if let ast::Stmt::CreateIndex(create_index) = item {
             if let Some(table_name) = create_index
                 .path()
                 .and_then(|x| x.segment())

--- a/crates/squawk_linter/src/rules/require_concurrent_index_deletion.rs
+++ b/crates/squawk_linter/src/rules/require_concurrent_index_deletion.rs
@@ -8,7 +8,7 @@ use crate::{Linter, Rule, Violation};
 pub(crate) fn require_concurrent_index_deletion(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
     for item in file.items() {
-        if let ast::Item::DropIndex(drop_index) = item {
+        if let ast::Stmt::DropIndex(drop_index) = item {
             if drop_index.concurrently_token().is_none() {
                 ctx.report(Violation::new(
                     Rule::RequireConcurrentIndexDeletion,

--- a/crates/squawk_linter/src/rules/transaction_nesting.rs
+++ b/crates/squawk_linter/src/rules/transaction_nesting.rs
@@ -12,7 +12,7 @@ pub(crate) fn transaction_nesting(ctx: &mut Linter, parse: &Parse<SourceFile>) {
 
     for item in file.items() {
         match item {
-            ast::Item::Begin(_) => {
+            ast::Stmt::Begin(_) => {
                 if ctx.settings.assume_in_transaction {
                     ctx.report(Violation::new(
                         Rule::TransactionNesting,
@@ -30,7 +30,7 @@ pub(crate) fn transaction_nesting(ctx: &mut Linter, parse: &Parse<SourceFile>) {
                 }
                 in_explicit_transaction = true;
             }
-            ast::Item::Commit(_) | ast::Item::Rollback(_) => {
+            ast::Stmt::Commit(_) | ast::Stmt::Rollback(_) => {
                 if ctx.settings.assume_in_transaction {
                     ctx.report(Violation::new(
                         Rule::TransactionNesting,

--- a/crates/squawk_linter/src/visitors.rs
+++ b/crates/squawk_linter/src/visitors.rs
@@ -41,7 +41,7 @@ pub(crate) fn check_not_allowed_types(
 ) {
     for item in file.items() {
         match item {
-            ast::Item::CreateTable(create_table) => {
+            ast::Stmt::CreateTable(create_table) => {
                 if let Some(table_args) = create_table.table_args() {
                     for arg in table_args.args() {
                         if let ast::TableArg::Column(column) = arg {
@@ -50,7 +50,7 @@ pub(crate) fn check_not_allowed_types(
                     }
                 }
             }
-            ast::Item::AlterTable(alter_table) => {
+            ast::Stmt::AlterTable(alter_table) => {
                 for action in alter_table.actions() {
                     match action {
                         ast::AlterTableAction::AddColumn(add_column) => {

--- a/crates/squawk_syntax/src/ast/nodes.rs
+++ b/crates/squawk_syntax/src/ast/nodes.rs
@@ -3175,7 +3175,7 @@ impl AstNode for Truncate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Item {
+pub enum Stmt {
     AlterTable(AlterTable),
     AlterDomain(AlterDomain),
     AlterAggregate(AlterAggregate),
@@ -3198,7 +3198,7 @@ pub enum Item {
 // impl ast::HasAttrs for Item {}
 // impl ast::HasDocComments for Item {}
 
-impl AstNode for Item {
+impl AstNode for Stmt {
     #[inline]
     fn can_cast(kind: SyntaxKind) -> bool {
         matches!(
@@ -3226,24 +3226,24 @@ impl AstNode for Item {
     #[inline]
     fn cast(syntax: SyntaxNode) -> Option<Self> {
         let res = match syntax.kind() {
-            SyntaxKind::SELECT => Item::Select(Select { syntax }),
-            SyntaxKind::CREATE_FUNCTION_STMT => Item::CreateFunc(CreateFunc { syntax }),
-            SyntaxKind::ALTER_TABLE => Item::AlterTable(AlterTable { syntax }),
-            SyntaxKind::DROP_DATABASE_STMT => Item::DropDatabase(DropDatabase { syntax }),
-            SyntaxKind::CREATE_TABLE => Item::CreateTable(CreateTable { syntax }),
-            SyntaxKind::BEGIN_STMT => Item::Begin(Begin { syntax }),
-            SyntaxKind::COMMIT_STMT => Item::Commit(Commit { syntax }),
-            SyntaxKind::CREATE_INDEX_STMT => Item::CreateIndex(CreateIndex { syntax }),
-            SyntaxKind::DROP_TABLE => Item::DropTable(DropTable { syntax }),
-            SyntaxKind::DROP_INDEX_STMT => Item::DropIndex(DropIndex { syntax }),
-            SyntaxKind::DROP_TYPE_STMT => Item::DropType(DropType { syntax }),
-            SyntaxKind::CREATE_DOMAIN_STMT => Item::CreateDomain(CreateDomain { syntax }),
-            SyntaxKind::ALTER_DOMAIN_STMT => Item::AlterDomain(AlterDomain { syntax }),
-            SyntaxKind::ALTER_AGGREGATE_STMT => Item::AlterAggregate(AlterAggregate { syntax }),
-            SyntaxKind::CREATE_AGGREGATE_STMT => Item::CreateAggregate(CreateAggregate { syntax }),
-            SyntaxKind::DROP_AGGREGATE_STMT => Item::DropAggregate(DropAggregate { syntax }),
-            SyntaxKind::ROLLBACK_STMT => Item::Rollback(Rollback { syntax }),
-            SyntaxKind::TRUNCATE_STMT => Item::Truncate(Truncate { syntax }),
+            SyntaxKind::SELECT => Stmt::Select(Select { syntax }),
+            SyntaxKind::CREATE_FUNCTION_STMT => Stmt::CreateFunc(CreateFunc { syntax }),
+            SyntaxKind::ALTER_TABLE => Stmt::AlterTable(AlterTable { syntax }),
+            SyntaxKind::DROP_DATABASE_STMT => Stmt::DropDatabase(DropDatabase { syntax }),
+            SyntaxKind::CREATE_TABLE => Stmt::CreateTable(CreateTable { syntax }),
+            SyntaxKind::BEGIN_STMT => Stmt::Begin(Begin { syntax }),
+            SyntaxKind::COMMIT_STMT => Stmt::Commit(Commit { syntax }),
+            SyntaxKind::CREATE_INDEX_STMT => Stmt::CreateIndex(CreateIndex { syntax }),
+            SyntaxKind::DROP_TABLE => Stmt::DropTable(DropTable { syntax }),
+            SyntaxKind::DROP_INDEX_STMT => Stmt::DropIndex(DropIndex { syntax }),
+            SyntaxKind::DROP_TYPE_STMT => Stmt::DropType(DropType { syntax }),
+            SyntaxKind::CREATE_DOMAIN_STMT => Stmt::CreateDomain(CreateDomain { syntax }),
+            SyntaxKind::ALTER_DOMAIN_STMT => Stmt::AlterDomain(AlterDomain { syntax }),
+            SyntaxKind::ALTER_AGGREGATE_STMT => Stmt::AlterAggregate(AlterAggregate { syntax }),
+            SyntaxKind::CREATE_AGGREGATE_STMT => Stmt::CreateAggregate(CreateAggregate { syntax }),
+            SyntaxKind::DROP_AGGREGATE_STMT => Stmt::DropAggregate(DropAggregate { syntax }),
+            SyntaxKind::ROLLBACK_STMT => Stmt::Rollback(Rollback { syntax }),
+            SyntaxKind::TRUNCATE_STMT => Stmt::Truncate(Truncate { syntax }),
             _ => return None,
         };
         Some(res)
@@ -3251,24 +3251,24 @@ impl AstNode for Item {
     #[inline]
     fn syntax(&self) -> &SyntaxNode {
         match self {
-            Item::Select(it) => &it.syntax,
-            Item::CreateFunc(it) => &it.syntax,
-            Item::AlterTable(it) => &it.syntax,
-            Item::DropDatabase(it) => &it.syntax,
-            Item::CreateTable(it) => &it.syntax,
-            Item::Begin(it) => &it.syntax,
-            Item::Commit(it) => &it.syntax,
-            Item::CreateIndex(it) => &it.syntax,
-            Item::DropTable(it) => &it.syntax,
-            Item::DropIndex(it) => &it.syntax,
-            Item::DropType(it) => &it.syntax,
-            Item::CreateDomain(it) => &it.syntax,
-            Item::AlterDomain(it) => &it.syntax,
-            Item::AlterAggregate(it) => &it.syntax,
-            Item::CreateAggregate(it) => &it.syntax,
-            Item::DropAggregate(it) => &it.syntax,
-            Item::Rollback(it) => &it.syntax,
-            Item::Truncate(it) => &it.syntax,
+            Stmt::Select(it) => &it.syntax,
+            Stmt::CreateFunc(it) => &it.syntax,
+            Stmt::AlterTable(it) => &it.syntax,
+            Stmt::DropDatabase(it) => &it.syntax,
+            Stmt::CreateTable(it) => &it.syntax,
+            Stmt::Begin(it) => &it.syntax,
+            Stmt::Commit(it) => &it.syntax,
+            Stmt::CreateIndex(it) => &it.syntax,
+            Stmt::DropTable(it) => &it.syntax,
+            Stmt::DropIndex(it) => &it.syntax,
+            Stmt::DropType(it) => &it.syntax,
+            Stmt::CreateDomain(it) => &it.syntax,
+            Stmt::AlterDomain(it) => &it.syntax,
+            Stmt::AlterAggregate(it) => &it.syntax,
+            Stmt::CreateAggregate(it) => &it.syntax,
+            Stmt::DropAggregate(it) => &it.syntax,
+            Stmt::Rollback(it) => &it.syntax,
+            Stmt::Truncate(it) => &it.syntax,
         }
     }
 }

--- a/crates/squawk_syntax/src/ast/traits.rs
+++ b/crates/squawk_syntax/src/ast/traits.rs
@@ -16,7 +16,7 @@ pub trait HasArgList: AstNode {
 }
 
 pub trait HasModuleItem: AstNode {
-    fn items(&self) -> AstChildren<ast::Item> {
+    fn items(&self) -> AstChildren<ast::Stmt> {
         support::children(self.syntax())
     }
 }

--- a/crates/squawk_syntax/src/lib.rs
+++ b/crates/squawk_syntax/src/lib.rs
@@ -207,7 +207,7 @@ fn api_walkthrough() {
     let mut func = None;
     for item in file.items() {
         match item {
-            ast::Item::CreateFunc(f) => func = Some(f),
+            ast::Stmt::CreateFunc(f) => func = Some(f),
             _ => unreachable!(),
         }
     }

--- a/crates/xtask/src/new_rule.rs
+++ b/crates/xtask/src/new_rule.rs
@@ -22,7 +22,7 @@ pub(crate) fn {rule_name_snake}(ctx: &mut Linter, parse: &Parse<SourceFile>) {{
     for item in file.items() {{
         match item {{
             // TODO: update to the item you want to check
-            ast::Item::CreateTable(create_table) => {{
+            ast::Stmt::CreateTable(create_table) => {{
                 ctx.report(Violation::new(
                     Rule::{rule_name_pascal},
                     "todo".to_string(),


### PR DESCRIPTION
working on ungrammar and this is more descriptive, rust-analyzer uses Item, but all top level things in postgres are statements