### PR TITLE
fix: paren data source

### DIFF
--- a/crates/squawk_parser/tests/data/ok/select.sql
+++ b/crates/squawk_parser/tests/data/ok/select.sql
@@ -356,6 +356,11 @@ select * from t full join t2 using (id);
 -- multi conditions
 select * from t join t2 on t2.team_id = t.team_id and t2.id = t.org_id;
 
+-- nested joins
+select f1, count(*) from
+t1 x(x0,x1) left join (t1 left join t2 using(f1)) on (x0 = 0)
+group by f1;
+
 -- using w/ join alias
 SELECT * from t join t2 using (id) as foo;
 
@@ -487,10 +492,10 @@ select current_schema;
 select * from t order by a using >>>;
 
 -- order_by_regression
-SELECT sensor_id, DATE_TRUNC('day', ts) AS day, MAX(value) AS max_value, MIN(value) AS min_value 
-FROM sensors_uncompressed 
+SELECT sensor_id, DATE_TRUNC('day', ts) AS day, MAX(value) AS max_value, MIN(value) AS min_value
+FROM sensors_uncompressed
 WHERE ts >= DATE '2023-12-21' AND ts < DATE '2023-12-22'
-GROUP BY sensor_id, DATE_TRUNC('day', ts) 
+GROUP BY sensor_id, DATE_TRUNC('day', ts)
 ORDER BY sensor_id, day;
 
 -- select_from_user_table

--- a/crates/squawk_parser/tests/snapshots/tests__join_using_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__join_using_ok.snap
@@ -1,0 +1,96 @@
+---
+source: crates/squawk_parser/tests/tests.rs
+input_file: crates/squawk_parser/tests/data/ok/join_using.sql
+snapshot_kind: text
+---
+SOURCE_FILE
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          NAME_REF
+            IDENT "f1"
+        COMMA ","
+        WHITESPACE " "
+        TARGET
+          CALL_EXPR
+            NAME_REF
+              IDENT "count"
+            ARG_LIST
+              L_PAREN "("
+              STAR "*"
+              R_PAREN ")"
+    WHITESPACE " "
+    FROM_CLAUSE
+      FROM_KW "from"
+      WHITESPACE "\n"
+      NAME_REF
+        IDENT "t1"
+      WHITESPACE " "
+      ALIAS
+        NAME
+          IDENT "x"
+        COLUMN_LIST
+          L_PAREN "("
+          COLUMN
+            NAME
+              IDENT "x0"
+          COMMA ","
+          COLUMN
+            NAME
+              IDENT "x1"
+          R_PAREN ")"
+      WHITESPACE " "
+      JOIN
+        LEFT_KW "left"
+        WHITESPACE " "
+        JOIN_KW "join"
+        WHITESPACE " "
+        PAREN_EXPR
+          L_PAREN "("
+          NAME_REF
+            IDENT "t1"
+          WHITESPACE " "
+          JOIN
+            LEFT_KW "left"
+            WHITESPACE " "
+            JOIN_KW "join"
+            WHITESPACE " "
+            NAME_REF
+              IDENT "t2"
+            WHITESPACE " "
+            USING_CLAUSE
+              USING_KW "using"
+              COLUMN_LIST
+                L_PAREN "("
+                COLUMN
+                  NAME_REF
+                    IDENT "f1"
+                R_PAREN ")"
+          R_PAREN ")"
+        WHITESPACE " "
+        ON_KW "on"
+        WHITESPACE " "
+        PAREN_EXPR
+          L_PAREN "("
+          BIN_EXPR
+            NAME_REF
+              IDENT "x0"
+            WHITESPACE " "
+            EQ "="
+            WHITESPACE " "
+            LITERAL
+              INT_NUMBER "0"
+          R_PAREN ")"
+    WHITESPACE "\n"
+    GROUP_BY_CLAUSE
+      GROUP_KW "group"
+      WHITESPACE " "
+      BY_KW "by"
+      WHITESPACE " "
+      NAME_REF
+        IDENT "f1"
+  SEMICOLON ";"
+  WHITESPACE "\n"

--- a/crates/squawk_parser/tests/snapshots/tests__misc_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__misc_ok.snap
@@ -3011,10 +3011,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "using"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "jobid"
+            COLUMN
+              NAME_REF
+                IDENT "jobid"
             R_PAREN ")"
     WHITESPACE "\n"
     WHERE_CLAUSE
@@ -6286,10 +6287,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "USING"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "turbine_id"
+            COLUMN
+              NAME_REF
+                IDENT "turbine_id"
             R_PAREN ")"
     WHITESPACE "\n"
     WHERE_CLAUSE

--- a/crates/squawk_parser/tests/snapshots/tests__select_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_ok.snap
@@ -4367,10 +4367,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "using"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "id"
+            COLUMN
+              NAME_REF
+                IDENT "id"
             R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n"
@@ -4399,14 +4400,16 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "using"
           WHITESPACE " "
-          TUPLE_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "id"
+            COLUMN
+              NAME_REF
+                IDENT "id"
             COMMA ","
             WHITESPACE " "
-            NAME_REF
-              IDENT "foo"
+            COLUMN
+              NAME_REF
+                IDENT "foo"
             R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -4437,10 +4440,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "using"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "id"
+            COLUMN
+              NAME_REF
+                IDENT "id"
             R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -4471,10 +4475,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "using"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "id"
+            COLUMN
+              NAME_REF
+                IDENT "id"
             R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -4540,6 +4545,98 @@ SOURCE_FILE
                 IDENT "org_id"
   SEMICOLON ";"
   WHITESPACE "\n\n"
+  COMMENT "-- nested joins"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          NAME_REF
+            IDENT "f1"
+        COMMA ","
+        WHITESPACE " "
+        TARGET
+          CALL_EXPR
+            NAME_REF
+              IDENT "count"
+            ARG_LIST
+              L_PAREN "("
+              STAR "*"
+              R_PAREN ")"
+    WHITESPACE " "
+    FROM_CLAUSE
+      FROM_KW "from"
+      WHITESPACE "\n"
+      NAME_REF
+        IDENT "t1"
+      WHITESPACE " "
+      ALIAS
+        NAME
+          IDENT "x"
+        COLUMN_LIST
+          L_PAREN "("
+          COLUMN
+            NAME
+              IDENT "x0"
+          COMMA ","
+          COLUMN
+            NAME
+              IDENT "x1"
+          R_PAREN ")"
+      WHITESPACE " "
+      JOIN
+        LEFT_KW "left"
+        WHITESPACE " "
+        JOIN_KW "join"
+        WHITESPACE " "
+        PAREN_EXPR
+          L_PAREN "("
+          NAME_REF
+            IDENT "t1"
+          WHITESPACE " "
+          JOIN
+            LEFT_KW "left"
+            WHITESPACE " "
+            JOIN_KW "join"
+            WHITESPACE " "
+            NAME_REF
+              IDENT "t2"
+            WHITESPACE " "
+            USING_CLAUSE
+              USING_KW "using"
+              COLUMN_LIST
+                L_PAREN "("
+                COLUMN
+                  NAME_REF
+                    IDENT "f1"
+                R_PAREN ")"
+          R_PAREN ")"
+        WHITESPACE " "
+        ON_KW "on"
+        WHITESPACE " "
+        PAREN_EXPR
+          L_PAREN "("
+          BIN_EXPR
+            NAME_REF
+              IDENT "x0"
+            WHITESPACE " "
+            EQ "="
+            WHITESPACE " "
+            LITERAL
+              INT_NUMBER "0"
+          R_PAREN ")"
+    WHITESPACE "\n"
+    GROUP_BY_CLAUSE
+      GROUP_KW "group"
+      WHITESPACE " "
+      BY_KW "by"
+      WHITESPACE " "
+      NAME_REF
+        IDENT "f1"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
   COMMENT "-- using w/ join alias"
   WHITESPACE "\n"
   SELECT
@@ -4565,10 +4662,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "using"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "id"
+            COLUMN
+              NAME_REF
+                IDENT "id"
             R_PAREN ")"
         WHITESPACE " "
         ALIAS
@@ -4708,10 +4806,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "using"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "id"
+            COLUMN
+              NAME_REF
+                IDENT "id"
             R_PAREN ")"
       WHITESPACE "\n"
       JOIN
@@ -4725,10 +4824,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "using"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              EVENT_KW "event"
+            COLUMN
+              NAME_REF
+                EVENT_KW "event"
             R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -4833,10 +4933,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "USING"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "did"
+            COLUMN
+              NAME_REF
+                IDENT "did"
             R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -4863,10 +4964,11 @@ SOURCE_FILE
         USING_CLAUSE
           USING_KW "using"
           WHITESPACE " "
-          PAREN_EXPR
+          COLUMN_LIST
             L_PAREN "("
-            NAME_REF
-              IDENT "a_id"
+            COLUMN
+              NAME_REF
+                IDENT "a_id"
             R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -5669,13 +5771,13 @@ SOURCE_FILE
           WHITESPACE " "
           NAME
             IDENT "min_value"
-    WHITESPACE " \n"
+    WHITESPACE "\n"
     FROM_CLAUSE
       FROM_KW "FROM"
       WHITESPACE " "
       NAME_REF
         IDENT "sensors_uncompressed"
-    WHITESPACE " \n"
+    WHITESPACE "\n"
     WHERE_CLAUSE
       WHERE_KW "WHERE"
       WHITESPACE " "
@@ -5729,7 +5831,7 @@ SOURCE_FILE
           NAME_REF
             IDENT "ts"
           R_PAREN ")"
-    WHITESPACE " \n"
+    WHITESPACE "\n"
     ORDER_BY_CLAUSE
       ORDER_KW "ORDER"
       WHITESPACE " "

--- a/crates/squawk_parser/tests/tests.rs
+++ b/crates/squawk_parser/tests/tests.rs
@@ -75,6 +75,7 @@ fn parser_err(fixture: Fixture<&str>) {
     );
 }
 
+// 102 failing
 #[dir_test(
     dir: "$CARGO_MANIFEST_DIR/tests/data/regression_suite",
     glob: "*.sql",


### PR DESCRIPTION
fixes data sources within parentheses. they can be either
- a select statement
- a join clause

this is now parsed properly:

```sql
select f1, count(*) from
  t1 x(x0,x1) left join (t1 left join t2 using(f1)) on (x0 = 0)
```
