### PR TITLE
cli: display syntax errors as errors, not warnings part 2

### DIFF
--- a/crates/squawk/src/debug.rs
+++ b/crates/squawk/src/debug.rs
@@ -86,7 +86,7 @@ fn render_syntax_errors(
     for err in errors {
         let text = err.message();
         let span = err.range().into();
-        let message = Level::Warning.title(text).id("syntax-error").snippet(
+        let message = Level::Error.title(text).id("syntax-error").snippet(
             Snippet::source(sql)
                 .origin(filename)
                 .fold(true)

--- a/crates/squawk/src/reporter.rs
+++ b/crates/squawk/src/reporter.rs
@@ -86,11 +86,16 @@ fn render_lint_error<W: std::io::Write>(
 
     let title = &err.message;
 
-    let mut message = Level::Warning.title(title).id(error_name).snippet(
+    let level = match err.level {
+        ViolationLevel::Warning => Level::Warning,
+        ViolationLevel::Error => Level::Error,
+    };
+
+    let mut message = level.title(title).id(error_name).snippet(
         Snippet::source(sql)
             .origin(filename)
             .fold(true)
-            .annotation(Level::Error.span(err.range.into())),
+            .annotation(level.span(err.range.into())),
     );
     if let Some(help) = &err.help {
         message = message.footer(Level::Help.title(help));

--- a/crates/squawk/src/snapshots/squawk__reporter__test_reporter__display_violations_tty.snap
+++ b/crates/squawk/src/snapshots/squawk__reporter__test_reporter__display_violations_tty.snap
@@ -1,45 +1,45 @@
 ---
-source: crates/cli/src/reporter.rs
+source: crates/squawk/src/reporter.rs
 expression: "strip_ansi_codes(&String::from_utf8_lossy(&buff))"
 ---
 warning[adding-required-field]: Adding a new column that is `NOT NULL` and has no default value to an existing table effectively makes it required.
  --> main.sql:2:30
   |
 2 |    ALTER TABLE "core_recipe" ADD COLUMN "foo" integer NOT NULL;
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                              ---------------------------------
   |
   = help: Make the field nullable or add a non-VOLATILE DEFAULT
 warning[prefer-robust-stmts]: Missing `IF NOT EXISTS`, the migration can't be rerun if it fails part way through.
  --> main.sql:2:30
   |
 2 |    ALTER TABLE "core_recipe" ADD COLUMN "foo" integer NOT NULL;
-  |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                              ---------------------------------
   |
 warning[prefer-bigint-over-int]: Using 32-bit integer fields can result in hitting the max `int` limit.
  --> main.sql:2:47
   |
 2 |    ALTER TABLE "core_recipe" ADD COLUMN "foo" integer NOT NULL;
-  |                                               ^^^^^^^
+  |                                               -------
   |
   = help: Use 64-bit integer values instead to prevent hitting this limit.
 warning[adding-required-field]: Adding a new column that is `NOT NULL` and has no default value to an existing table effectively makes it required.
  --> main.sql:3:24
   |
 3 | ALTER TABLE "core_foo" ADD COLUMN "bar" integer NOT NULL;
-  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                        ---------------------------------
   |
   = help: Make the field nullable or add a non-VOLATILE DEFAULT
 warning[prefer-robust-stmts]: Missing `IF NOT EXISTS`, the migration can't be rerun if it fails part way through.
  --> main.sql:3:24
   |
 3 | ALTER TABLE "core_foo" ADD COLUMN "bar" integer NOT NULL;
-  |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                        ---------------------------------
   |
 warning[prefer-bigint-over-int]: Using 32-bit integer fields can result in hitting the max `int` limit.
  --> main.sql:3:41
   |
 3 | ALTER TABLE "core_foo" ADD COLUMN "bar" integer NOT NULL;
-  |                                         ^^^^^^^
+  |                                         -------
   |
   = help: Use 64-bit integer values instead to prevent hitting this limit.
 


### PR DESCRIPTION
We were showing warning for everything and then using the error level for highlighting the error.

Now we set the level correctly!