### PR TITLE
linter: fix typo in PreferTimestampTz rule name

### DIFF
--- a/crates/squawk_linter/src/ignore.rs
+++ b/crates/squawk_linter/src/ignore.rs
@@ -212,4 +212,21 @@ create table users (
         let errors = linter.lint(parse, sql);
         assert_eq!(errors.len(), 1);
     }
+
+    #[test]
+    fn regression_unknown_name() {
+        let mut linter = Linter::with_all_rules();
+        let sql = r#"
+-- squawk-ignore prefer-robust-stmts
+create table test_table (
+  -- squawk-ignore prefer-timestamp-tz
+  created_at timestamp default current_timestamp,
+  other_field text
+);
+        "#;
+
+        let parse = squawk_syntax::SourceFile::parse(sql);
+        let errors = linter.lint(parse, sql);
+        assert_eq!(errors.len(), 0);
+    }
 }

--- a/crates/squawk_linter/src/lib.rs
+++ b/crates/squawk_linter/src/lib.rs
@@ -136,7 +136,9 @@ impl TryFrom<&str> for Rule {
             "prefer-identity" => Ok(Rule::PreferIdentity),
             "prefer-robust-stmts" => Ok(Rule::PreferRobustStmts),
             "prefer-text-field" => Ok(Rule::PreferTextField),
+            // this is typo'd so we just support both
             "prefer-timestamptz" => Ok(Rule::PreferTimestampTz),
+            "prefer-timestamp-tz" => Ok(Rule::PreferTimestampTz),
             "ban-char-field" => Ok(Rule::BanCharField),
             "ban-drop-column" => Ok(Rule::BanDropColumn),
             "ban-drop-table" => Ok(Rule::BanDropTable),


### PR DESCRIPTION
rel: https://github.com/sbdchd/squawk/issues/508