### PR TITLE
linter: fix regression in adding_not_null_field related to v2 rewrite

### DIFF
--- a/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__adding_not_null_field__test__regression_gh_issue_519.snap
+++ b/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__adding_not_null_field__test__regression_gh_issue_519.snap
@@ -1,0 +1,14 @@
+---
+source: crates/squawk_linter/src/rules/adding_not_null_field.rs
+expression: errors
+---
+[
+    Violation {
+        code: AddingNotNullableField,
+        message: "Setting a column `NOT NULL` blocks reads while the table is scanned.",
+        text_range: 78..90,
+        help: Some(
+            "Make the field nullable and use a `CHECK` constraint instead.",
+        ),
+    },
+]


### PR DESCRIPTION
I think the changes from https://github.com/sbdchd/squawk/pull/412 / https://github.com/sbdchd/squawk/commit/360e3ee53edddfcfd63d0944699c7c7ab31ab7f3 didn't make it into the v2 codebase.

rel: https://github.com/sbdchd/squawk/issues/519