### PR TITLE
parser: fix paren select issues

### DIFF
--- a/crates/squawk_parser/tests/snapshots/tests__regression_inherit.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__regression_inherit.snap
@@ -2,37 +2,4 @@
 source: crates/squawk_parser/tests/tests.rs
 input_file: crates/squawk_parser/tests/data/regression_suite/inherit.sql
 ---
-ERROR@30331: expected R_PAREN
-ERROR@30426: missing comma
-ERROR@30455: expected SEMICOLON
-ERROR@30455: expected command, found R_PAREN
-ERROR@30457: expected command, found FROM_KW
-ERROR@30462: expected command, found IDENT
-ERROR@30478: expected R_PAREN
-ERROR@30478: expected SEMICOLON
-ERROR@30478: expected command, found INT_NUMBER
-ERROR@30479: expected command, found COMMA
-ERROR@30481: expected command, found INT_NUMBER
-ERROR@30482: expected command, found R_PAREN
-ERROR@30484: expected command, found IDENT
-ERROR@30486: expected R_PAREN
-ERROR@30486: expected SEMICOLON
-ERROR@30486: expected command, found IDENT
-ERROR@30487: expected command, found R_PAREN
-ERROR@30594: expected R_PAREN
-ERROR@30689: missing comma
-ERROR@30718: expected SEMICOLON
-ERROR@30718: expected command, found R_PAREN
-ERROR@30720: expected command, found FROM_KW
-ERROR@30725: expected command, found IDENT
-ERROR@30741: expected R_PAREN
-ERROR@30741: expected SEMICOLON
-ERROR@30741: expected command, found INT_NUMBER
-ERROR@30742: expected command, found COMMA
-ERROR@30744: expected command, found INT_NUMBER
-ERROR@30745: expected command, found R_PAREN
-ERROR@30747: expected command, found IDENT
-ERROR@30749: expected R_PAREN
-ERROR@30749: expected SEMICOLON
-ERROR@30749: expected command, found IDENT
-ERROR@30750: expected command, found R_PAREN
+

--- a/crates/squawk_parser/tests/snapshots/tests__regression_join.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__regression_join.snap
@@ -2,23 +2,4 @@
 source: crates/squawk_parser/tests/tests.rs
 input_file: crates/squawk_parser/tests/data/regression_suite/join.sql
 ---
-ERROR@93160: expected R_PAREN
-ERROR@93186: expected SEMICOLON
-ERROR@93186: expected command, found R_PAREN
-ERROR@93188: expected command, found AS_KW
-ERROR@93191: expected command, found IDENT
-ERROR@93196: expected command, found CROSS_KW
-ERROR@93202: expected command, found JOIN_KW
-ERROR@93207: expected command, found LATERAL_KW
-ERROR@93255: expected R_PAREN
-ERROR@93282: expected R_PAREN
-ERROR@93282: expected SEMICOLON
-ERROR@93283: expected command, found AS_KW
-ERROR@93286: expected command, found IDENT
-ERROR@93288: expected command, found R_PAREN
-ERROR@93293: expected command, found UNION_KW
-ERROR@93299: expected command, found ALL_KW
-ERROR@93319: expected SEMICOLON
-ERROR@93322: expected command, found R_PAREN
-ERROR@93324: expected command, found AS_KW
-ERROR@93327: expected command, found IDENT
+

--- a/crates/squawk_parser/tests/snapshots/tests__regression_privileges.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__regression_privileges.snap
@@ -2,17 +2,4 @@
 source: crates/squawk_parser/tests/tests.rs
 input_file: crates/squawk_parser/tests/data/regression_suite/privileges.sql
 ---
-ERROR@17722: expected R_PAREN
-ERROR@17782: expected SEMICOLON
-ERROR@17782: expected command, found R_PAREN
-ERROR@17784: expected command, found IDENT
-ERROR@17787: expected command, found WHERE_KW
-ERROR@17793: expected command, found FALSE_KW
-ERROR@17906: expected R_PAREN
-ERROR@17980: expected SEMICOLON
-ERROR@17980: expected command, found R_PAREN
-ERROR@17982: expected command, found IDENT
-ERROR@17985: expected command, found WHERE_KW
-ERROR@17991: expected command, found IDENT
-ERROR@17993: expected command, found L_ANGLE
-ERROR@17995: expected command, found INT_NUMBER
+

--- a/crates/squawk_parser/tests/snapshots/tests__regression_suite_errors.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__regression_suite_errors.snap
@@ -2,10 +2,6 @@
 source: crates/squawk_parser/tests/tests.rs
 expression: "out.join(\"\\n\")"
 ---
-tests/snapshots/tests__regression_inherit.snap:34
-tests/snapshots/tests__regression_join.snap:20
 tests/snapshots/tests__regression_merge.snap:61
-tests/snapshots/tests__regression_privileges.snap:14
 tests/snapshots/tests__regression_strings.snap:49
-tests/snapshots/tests__regression_union.snap:15
 tests/snapshots/tests__regression_xml.snap:382

--- a/crates/squawk_parser/tests/snapshots/tests__regression_union.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__regression_union.snap
@@ -2,18 +2,4 @@
 source: crates/squawk_parser/tests/tests.rs
 input_file: crates/squawk_parser/tests/data/regression_suite/union.sql
 ---
-ERROR@996: expected SEMICOLON
-ERROR@997: expected command, found ORDER_KW
-ERROR@1003: expected command, found BY_KW
-ERROR@1006: expected command, found INT_NUMBER
-ERROR@10339: expected SEMICOLON
-ERROR@10340: expected command, found ORDER_KW
-ERROR@10346: expected command, found BY_KW
-ERROR@10349: expected command, found INT_NUMBER
-ERROR@11233: expected SEMICOLON
-ERROR@11234: expected command, found ORDER_KW
-ERROR@11240: expected command, found BY_KW
-ERROR@11243: expected command, found INT_NUMBER
-ERROR@18725: expected SEMICOLON
-ERROR@18726: expected command, found LIMIT_KW
-ERROR@18732: expected command, found INT_NUMBER
+

--- a/crates/squawk_parser/tests/snapshots/tests__select_compound_union_select_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_compound_union_select_ok.snap
@@ -77,7 +77,7 @@ SOURCE_FILE
               WHITESPACE "\n    "
               UNION_KW "UNION"
               WHITESPACE "\n    "
-              PAREN_EXPR
+              PAREN_SELECT
                 L_PAREN "("
                 SELECT
                   SELECT_CLAUSE


### PR DESCRIPTION
we weren't parsing trailing clauses for paren select and had some dupe paren select logic hanging around.