### PR TITLE
vscode: add status bar item to show server logs

### DIFF
--- a/crates/squawk/src/main.rs
+++ b/crates/squawk/src/main.rs
@@ -220,7 +220,7 @@ Please open an issue at https://github.com/sbdchd/squawk/issues/new with the log
     if let Some(subcommand) = opts.cmd {
         match subcommand {
             Command::Server => {
-                squawk_server::run_server().context("language server failed")?;
+                squawk_server::run().context("language server failed")?;
             }
             Command::UploadToGithub(args) => {
                 github::check_and_comment_on_pr(

--- a/docs/docs/syntax-error.md
+++ b/docs/docs/syntax-error.md
@@ -1,0 +1,43 @@
+---
+id: syntax-error
+title: syntax-error
+---
+
+## problem
+
+Squawk encountered invalid syntax when parsing.
+
+## examples
+
+trailing comma
+
+```sql
+select f(1,2,);
+-- error[syntax-error]: unexpected trailing comma
+--  --> stdin:1:13
+--   |
+-- 1 | select f(1,2,);
+--   |             ^
+--   |
+```
+
+missing semicolon
+
+```sql
+select * from t
+select id from users where email = email;
+-- error[syntax-error]: expected SEMICOLON
+--  --> stdin:1:16
+--   |
+-- 1 | select * from t
+--   |                ^
+--   |
+```
+
+## solutions
+
+Fix the syntax error.
+
+:::note
+Squawk might be mistaken, if you think that's the case, please [open an issue](https://github.com/sbdchd/squawk/issues/new)!
+:::

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -31,6 +31,7 @@ module.exports = {
       "ban-create-domain-with-constraint",
       "ban-alter-domain-with-add-constraint",
       "ban-truncate-cascade",
+      "syntax-error",
       // xtask:new-rule:error-name
     ],
   },

--- a/squawk-vscode/package.json
+++ b/squawk-vscode/package.json
@@ -36,6 +36,11 @@
         "command": "squawk.serverVersion",
         "title": "Show Server Version",
         "category": "Squawk"
+      },
+      {
+        "command": "squawk.showLogs",
+        "title": "Show Server Logs",
+        "category": "Squawk"
       }
     ],
     "languages": [

--- a/squawk-vscode/src/extension.ts
+++ b/squawk-vscode/src/extension.ts
@@ -32,6 +32,24 @@ export async function activate(context: vscode.ExtensionContext) {
   )
   context.subscriptions.push(serverVersionCommand)
 
+  const showLogsCommand = vscode.commands.registerCommand(
+    "squawk.showLogs",
+    () => {
+      client?.outputChannel?.show()
+    },
+  )
+  context.subscriptions.push(showLogsCommand)
+
+  const statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100,
+  )
+  statusBarItem.text = "Squawk"
+  statusBarItem.tooltip = "Click to show Squawk Language Server logs"
+  statusBarItem.command = "squawk.showLogs"
+  statusBarItem.show()
+  context.subscriptions.push(statusBarItem)
+
   await startServer(context)
 }
 
@@ -66,10 +84,7 @@ async function startServer(context: vscode.ExtensionContext) {
   }
   const serverOptions: ServerOptions = serverExecutable
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-      { scheme: "file", language: "sql" },
-      { scheme: "file", language: "postgres" },
-    ],
+    documentSelector: [{ language: "sql" }, { language: "postgres" }],
     outputChannel: vscode.window.createOutputChannel("Squawk Language Server"),
   }
   client = new LanguageClient(


### PR DESCRIPTION
also:

- add missing docs page for syntax errors
- clear diagnostics on file close -- fixes stale diagnostics when switching file type from sql to plain text

<img width="284" alt="image" src="https://github.com/user-attachments/assets/891b150b-15cd-4ea4-8336-15abfdf67ee4" />
