### PR TITLE
Revert "internal: publish cli to crates.io in ci (#577)"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -176,24 +176,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 
-  publish-crates-io:
-    if: startsWith(github.ref, 'refs/tags/')
-    needs: [build]
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Toolchain
-        uses: dtolnay/rust-toolchain@4305c38b25d97ef35a8ad1f985ccf2d2242004f2 # stable
-        with:
-          toolchain: 1.88.0
-      - name: Cache
-        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # pin@v2
-      - name: Publish to crates.io
-        run: cargo publish --package squawk
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-
   publish-docker:
     if: startsWith(github.ref, 'refs/tags/')
     needs: [build]


### PR DESCRIPTION
This reverts commit 786daa744bfccb163a6dd82dbb508008c9917ef9.


turns out we need to publish all sub crates, need to think about it more