### PR TITLE
linter: detect invalid uppercase types

### DIFF
--- a/crates/squawk_linter/src/rules/prefer_identity.rs
+++ b/crates/squawk_linter/src/rules/prefer_identity.rs
@@ -67,18 +67,21 @@ create table users (
 create table users (
     id bigserial
 );
+create table users (
+    id BIGSERIAL
+);
         "#;
         let file = squawk_syntax::SourceFile::parse(sql);
         let mut linter = Linter::from([Rule::PreferIdentity]);
         let errors = linter.lint(file, sql);
         assert_ne!(errors.len(), 0);
-        assert_eq!(errors.len(), 6);
+        assert_eq!(errors.len(), 7);
         assert_eq!(
             errors
                 .iter()
                 .filter(|x| x.code == Rule::PreferIdentity)
                 .count(),
-            6
+            7
         );
         assert_debug_snapshot!(errors);
     }

--- a/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_identity__test__err.snap
+++ b/crates/squawk_linter/src/rules/snapshots/squawk_linter__rules__prefer_identity__test__err.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/squawk_linter/src/rules/prefer_identity.rs
+assertion_line: 86
 expression: errors
 ---
 [
@@ -47,6 +48,14 @@ expression: errors
         code: PreferIdentity,
         message: "Serial types make schema, dependency, and permission management difficult.",
         text_range: 227..236,
+        help: Some(
+            "Use an `IDENTITY` column instead.",
+        ),
+    },
+    Violation {
+        code: PreferIdentity,
+        message: "Serial types make schema, dependency, and permission management difficult.",
+        text_range: 268..277,
         help: Some(
             "Use an `IDENTITY` column instead.",
         ),

--- a/crates/squawk_linter/src/visitors.rs
+++ b/crates/squawk_linter/src/visitors.rs
@@ -24,7 +24,7 @@ pub(crate) fn is_not_valid_int_type(ty: &ast::Type, invalid_type_names: &HashSet
                 return false;
             };
             let name = trim_quotes(ty_name.as_str());
-            invalid_type_names.contains(name)
+            invalid_type_names.contains(name.to_lowercase().as_str())
         }
         ast::Type::CharType(_) => false,
         ast::Type::BitType(_) => false,


### PR DESCRIPTION
Keywords in PostgreSQL are always case-insensitive[1], therefore `BIGSERIAL` and `BiGsErIaL` types should be considered the same as `bigserial`.

[1] https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS