### PR TITLE
github: support overriding api url

### DIFF
--- a/crates/squawk/src/github.rs
+++ b/crates/squawk/src/github.rs
@@ -33,6 +33,7 @@ fn get_github_private_key(
 }
 
 fn create_gh_app(
+    github_api_url: Option<String>,
     github_install_id: Option<i64>,
     github_app_id: Option<i64>,
     github_token: Option<String>,
@@ -51,7 +52,11 @@ fn create_gh_app(
 
     if let Some(github_token) = github_token {
         info!("using github actions client");
-        return Ok(Box::new(actions::GitHub::new(&github_token)));
+        let client = match github_api_url {
+            Some(github_api_url) => actions::GitHub::new_with_url(&github_api_url, &github_token),
+            None => actions::GitHub::new(&github_token),
+        };
+        return Ok(Box::new(client));
     };
     bail!(
         "Missing GitHub credentials:
@@ -84,6 +89,7 @@ pub fn check_and_comment_on_pr(
         paths,
         fail_on_violations,
         github_private_key,
+        github_api_url,
         github_token,
         github_app_id,
         github_install_id,
@@ -101,6 +107,7 @@ pub fn check_and_comment_on_pr(
         };
 
     let github_app = create_gh_app(
+        github_api_url,
         github_install_id,
         github_app_id,
         github_token,

--- a/crates/squawk/src/main.rs
+++ b/crates/squawk/src/main.rs
@@ -32,6 +32,9 @@ pub struct UploadToGithubArgs {
     github_private_key: Option<String>,
     #[structopt(long, env = "SQUAWK_GITHUB_PRIVATE_KEY_BASE64")]
     github_private_key_base64: Option<String>,
+    /// GitHub API url.
+    #[structopt(long, env = "SQUAWK_GITHUB_API_URL")]
+    github_api_url: Option<String>,
     #[structopt(long, env = "SQUAWK_GITHUB_TOKEN")]
     github_token: Option<String>,
     /// GitHub App Id.

--- a/crates/squawk_github/src/actions.rs
+++ b/crates/squawk_github/src/actions.rs
@@ -1,13 +1,20 @@
 use crate::app;
-use crate::{Comment, GitHubApi, GithubError};
+use crate::{Comment, DEFAULT_GITHUB_API_URL, GitHubApi, GithubError};
 
 pub struct GitHub {
+    github_api_url: String,
     github_token: String,
 }
 impl GitHub {
     #[must_use]
     pub fn new(github_token: &str) -> Self {
+        Self::new_with_url(DEFAULT_GITHUB_API_URL, github_token)
+    }
+
+    #[must_use]
+    pub fn new_with_url(github_api_url: &str, github_token: &str) -> Self {
         GitHub {
+            github_api_url: github_api_url.to_string(),
             github_token: github_token.to_string(),
         }
     }
@@ -24,6 +31,7 @@ impl GitHubApi for GitHub {
         body: &str,
     ) -> Result<(), GithubError> {
         app::create_comment(
+            &self.github_api_url,
             app::CommentArgs {
                 owner: owner.to_string(),
                 repo: repo.to_string(),
@@ -40,6 +48,7 @@ impl GitHubApi for GitHub {
         issue_id: i64,
     ) -> Result<Vec<Comment>, GithubError> {
         app::list_comments(
+            &self.github_api_url,
             &app::PullRequest {
                 issue: issue_id,
                 owner: owner.to_string(),
@@ -56,6 +65,7 @@ impl GitHubApi for GitHub {
         body: &str,
     ) -> Result<(), GithubError> {
         app::update_comment(
+            &self.github_api_url,
             owner,
             repo,
             comment_id,

--- a/crates/squawk_github/src/lib.rs
+++ b/crates/squawk_github/src/lib.rs
@@ -8,6 +8,8 @@ use std::error::Error;
 use log::info;
 use serde::{Deserialize, Serialize};
 
+pub(crate) const DEFAULT_GITHUB_API_URL: &'static str = "https://api.github.com";
+
 #[derive(Debug)]
 pub enum GithubError {
     JsonWebTokenCreation(jsonwebtoken::errors::Error),


### PR DESCRIPTION
fixes #609

NOTE: I haven't tested this yet, what's the best way of doing that? (And are we fine with taking the URL verbatim? This should be fine I think?).

(this goes along with https://github.com/sbdchd/squawk-action/pull/30)