### PR TITLE
parser: fix parsing paths named `operator`

### DIFF
--- a/crates/squawk_parser/src/grammar.rs
+++ b/crates/squawk_parser/src/grammar.rs
@@ -1552,7 +1552,12 @@ fn opt_name(p: &mut Parser<'_>) -> Option<CompletedMarker> {
 fn path_segment(p: &mut Parser<'_>, kind: SyntaxKind) {
     let m = p.start();
     // TODO: does this need to be flagged?
-    if current_operator(p).is_some() {
+    // Might want to disallow operators in some paths.
+    // Like `create table +()` doesn't make sense.
+    if !p.at(OPERATOR_KW) && current_operator(p).is_some() {
+        // check for operator kw so we can parse things like:
+        //   create table operator();
+
         // skip
     } else if p.at_ts(COL_LABEL_FIRST) {
         let m = p.start();

--- a/crates/squawk_parser/tests/data/ok/create_table.sql
+++ b/crates/squawk_parser/tests/data/ok/create_table.sql
@@ -351,3 +351,7 @@ create table t (
   d int storage main,
   e int storage default
 );
+
+create table operator (
+  x int
+);

--- a/crates/squawk_parser/tests/snapshots/tests__create_table_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__create_table_ok.snap
@@ -3379,4 +3379,30 @@ SOURCE_FILE
       WHITESPACE "\n"
       R_PAREN ")"
   SEMICOLON ";"
+  WHITESPACE "\n\n"
+  CREATE_TABLE
+    CREATE_KW "create"
+    WHITESPACE " "
+    TABLE_KW "table"
+    WHITESPACE " "
+    PATH
+      PATH_SEGMENT
+        NAME
+          OPERATOR_KW "operator"
+    WHITESPACE " "
+    TABLE_ARG_LIST
+      L_PAREN "("
+      WHITESPACE "\n  "
+      COLUMN
+        NAME
+          IDENT "x"
+        WHITESPACE " "
+        PATH_TYPE
+          PATH
+            PATH_SEGMENT
+              NAME_REF
+                INT_KW "int"
+      WHITESPACE "\n"
+      R_PAREN ")"
+  SEMICOLON ";"
   WHITESPACE "\n"


### PR DESCRIPTION
rel: https://github.com/sbdchd/squawk/issues/635