### PR TITLE
github: fix calling API erroring

### DIFF
--- a/crates/squawk_github/src/actions.rs
+++ b/crates/squawk_github/src/actions.rs
@@ -1,4 +1,7 @@
+use log::info;
+
 use crate::app;
+use crate::app::SQUAWK_USER_AGENT;
 use crate::{Comment, DEFAULT_GITHUB_API_URL, GitHubApi, GithubError};
 
 pub struct GitHub {
@@ -13,6 +16,7 @@ impl GitHub {
 
     #[must_use]
     pub fn new_with_url(github_api_url: &str, github_token: &str) -> Self {
+        info!("github user agent {SQUAWK_USER_AGENT}");
         GitHub {
             github_api_url: github_api_url.to_string(),
             github_token: github_token.to_string(),

--- a/crates/squawk_github/src/app.rs
+++ b/crates/squawk_github/src/app.rs
@@ -5,11 +5,13 @@ use crate::{Comment, DEFAULT_GITHUB_API_URL, GitHubApi, GithubError};
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 
 use log::info;
-use reqwest::header::{ACCEPT, AUTHORIZATION};
+use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+pub(crate) const SQUAWK_USER_AGENT: &str = "squawk/2.25.0";
 
 #[derive(Debug, Serialize)]
 struct CommentBody {
@@ -43,6 +45,7 @@ fn create_access_token(
         ))
         .header(AUTHORIZATION, format!("Bearer {jwt}"))
         .header(ACCEPT, "application/vnd.github.machine-man-preview+json")
+        .header(USER_AGENT, SQUAWK_USER_AGENT)
         .send()?
         .error_for_status()?
         .json::<GithubAccessToken>()?)
@@ -70,6 +73,7 @@ pub(crate) fn create_comment(
             issue_number = comment.issue
         ))
         .header(AUTHORIZATION, format!("Bearer {secret}"))
+        .header(USER_AGENT, SQUAWK_USER_AGENT)
         .json(&comment_body)
         .send()?
         .error_for_status()?;
@@ -87,6 +91,7 @@ pub fn get_app_info(github_api_url: &str, jwt: &str) -> Result<GitHubAppInfo, Gi
     Ok(reqwest::blocking::Client::new()
         .get(&format!("{github_api_url}/app"))
         .header(AUTHORIZATION, format!("Bearer {jwt}"))
+        .header(USER_AGENT, SQUAWK_USER_AGENT)
         .send()?
         .error_for_status()?
         .json::<GitHubAppInfo>()?)
@@ -176,6 +181,7 @@ pub(crate) fn list_comments(
         ))
         .query(&[("per_page", 100)])
         .header(AUTHORIZATION, format!("Bearer {secret}",))
+        .header(USER_AGENT, SQUAWK_USER_AGENT)
         .send()?
         .error_for_status()?
         .json::<Vec<Comment>>()?)
@@ -203,6 +209,7 @@ pub(crate) fn update_comment(
             "{github_api_url}/repos/{owner}/{repo}/issues/comments/{comment_id}",
         ))
         .header(AUTHORIZATION, format!("Bearer {secret}"))
+        .header(USER_AGENT, SQUAWK_USER_AGENT)
         .json(&CommentBody { body })
         .send()?
         .error_for_status()?;

--- a/s/update-version
+++ b/s/update-version
@@ -30,10 +30,14 @@ main() {
     fastmod --accept-all '"version": ".*"' '"version": "'$NEW_VERSION'"' package.json
     fastmod --accept-all '"version": ".*"' '"version": "'$NEW_VERSION'"' squawk-vscode/package.json
     fastmod --accept-all -m '(pname = "squawk";.*?)version = ".*?"' '${1}version = "'$NEW_VERSION'"' flake.nix
+    fastmod --accept-all 'pub(crate) const SQUAWK_USER_AGENT: &str = "squawk/.*"' 'pub(crate) const SQUAWK_USER_AGENT: &str = "squawk/'$NEW_VERSION'"' crates/squawk_github/src/app.rs
     
     echo "Updating CHANGELOG.md..."
     CURRENT_DATE=$(date +"%Y-%m-%d")
     sed -i '' "s/^## \[Unreleased\]$/## [Unreleased]\n\n## v$NEW_VERSION - $CURRENT_DATE/" CHANGELOG.md
+    
+    echo "Opening CHANGELOG.md for editing..."
+    ${EDITOR:-vi} CHANGELOG.md
 }
 
 


### PR DESCRIPTION
for some reason github started blocking calls, maybe related to the http tls change?

adding a user agent worked.


rel: https://github.com/sbdchd/squawk-action/issues/31