### PR TITLE
parser: fix nodes for casts so ast access works correctly

### DIFF
--- a/crates/squawk_linter/src/rules/prefer_text_field.rs
+++ b/crates/squawk_linter/src/rules/prefer_text_field.rs
@@ -47,6 +47,7 @@ fn is_not_allowed_varchar(ty: &ast::Type) -> bool {
         ast::Type::DoubleType(_) => false,
         ast::Type::TimeType(_) => false,
         ast::Type::IntervalType(_) => false,
+        ast::Type::ExprType(_) => false,
     }
 }
 

--- a/crates/squawk_linter/src/rules/prefer_timestamptz.rs
+++ b/crates/squawk_linter/src/rules/prefer_timestamptz.rs
@@ -42,6 +42,7 @@ pub fn is_not_allowed_timestamp(ty: &ast::Type) -> bool {
             false
         }
         ast::Type::IntervalType(_) => false,
+        ast::Type::ExprType(_) => false,
     }
 }
 

--- a/crates/squawk_linter/src/visitors.rs
+++ b/crates/squawk_linter/src/visitors.rs
@@ -34,6 +34,7 @@ pub(crate) fn is_not_valid_int_type(
         ast::Type::DoubleType(_) => false,
         ast::Type::TimeType(_) => false,
         ast::Type::IntervalType(_) => false,
+        ast::Type::ExprType(_) => false,
     }
 }
 

--- a/crates/squawk_parser/src/generated/syntax_kind.rs
+++ b/crates/squawk_parser/src/generated/syntax_kind.rs
@@ -756,6 +756,7 @@ pub enum SyntaxKind {
     EXCLUDE_CONSTRAINT,
     EXECUTE,
     EXPLAIN,
+    EXPR_TYPE,
     FAT_ARROW,
     FETCH,
     FETCH_CLAUSE,

--- a/crates/squawk_parser/tests/data/ok/select_casts.sql
+++ b/crates/squawk_parser/tests/data/ok/select_casts.sql
@@ -7,6 +7,7 @@ select int8('1234');
 select 44::bit(3);
 select cast(-44 as bit(12));
 select '1110'::bit(4)::integer;
+select '{1}'::pg_catalog.varchar(1)[];
 
 select '{1,2,3}'::int[];
 select foo::int;
@@ -206,6 +207,8 @@ select '{1}'::pg_catalog.int8[];
 
 -- cast
 select cast(a as foo.bar);
+select cast('{1}' as pg_catalog.varchar(1)[]);
+
 
 -- treat
 select treat(a as foo.b);
@@ -268,3 +271,4 @@ select boolean 'false';
 
 select foo.bar '100';
 select foo.bar(10, 2) '100';
+select pg_catalog.varchar(100) '{123}';

--- a/crates/squawk_parser/tests/snapshots/tests__create_view_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__create_view_ok.snap
@@ -46,8 +46,11 @@ SOURCE_FILE
         TARGET_LIST
           TARGET
             CAST_EXPR
-              NAME_REF
-                TEXT_KW "text"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      TEXT_KW "text"
               WHITESPACE " "
               LITERAL
                 STRING "'Hello World'"

--- a/crates/squawk_parser/tests/snapshots/tests__explain_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__explain_ok.snap
@@ -538,8 +538,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                INTEGER_KW "integer"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      INTEGER_KW "integer"
           WHITESPACE " "
           AND_KW "AND"
           WHITESPACE " "
@@ -555,8 +558,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                INTEGER_KW "integer"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      INTEGER_KW "integer"
       WHITESPACE "\n    "
       GROUP_BY_CLAUSE
         GROUP_KW "GROUP"

--- a/crates/squawk_parser/tests/snapshots/tests__misc_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__misc_ok.snap
@@ -104,11 +104,12 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                INDEX_EXPR
-                  NAME_REF
-                    IDENT "timestamptz"
-                  L_BRACK "["
-                  R_BRACK "]"
+                EXPR_TYPE
+                  INDEX_EXPR
+                    NAME_REF
+                      IDENT "timestamptz"
+                    L_BRACK "["
+                    R_BRACK "]"
               COMMA ","
               WHITESPACE " \n    "
               CAST_EXPR
@@ -117,11 +118,12 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                INDEX_EXPR
-                  NAME_REF
-                    TEXT_KW "text"
-                  L_BRACK "["
-                  R_BRACK "]"
+                EXPR_TYPE
+                  INDEX_EXPR
+                    NAME_REF
+                      TEXT_KW "text"
+                    L_BRACK "["
+                    R_BRACK "]"
               COMMA ","
               WHITESPACE " \n    "
               CAST_EXPR
@@ -130,11 +132,12 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                INDEX_EXPR
-                  NAME_REF
-                    IDENT "float8"
-                  L_BRACK "["
-                  R_BRACK "]"
+                EXPR_TYPE
+                  INDEX_EXPR
+                    NAME_REF
+                      IDENT "float8"
+                    L_BRACK "["
+                    R_BRACK "]"
               WHITESPACE "\n"
               R_PAREN ")"
   SEMICOLON ";"
@@ -677,8 +680,11 @@ SOURCE_FILE
                     COLON_COLON
                       COLON ":"
                       COLON ":"
-                    NAME_REF
-                      IDENT "jsonb"
+                    PATH_TYPE
+                      PATH
+                        PATH_SEGMENT
+                          NAME_REF
+                            IDENT "jsonb"
                   COMMA ","
                   WHITESPACE "\n        "
                   NAMED_ARG
@@ -1015,8 +1021,11 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                NAME_REF
-                  IDENT "int4"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "int4"
               COMMA ","
               WHITESPACE " "
               NAME_REF
@@ -1071,8 +1080,11 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                NAME_REF
-                  IDENT "int4"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "int4"
               COMMA ","
               WHITESPACE " "
               NAME_REF
@@ -1258,8 +1270,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              IDENT "date"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "date"
           R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -1331,8 +1346,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              IDENT "date"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "date"
           R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -2102,8 +2120,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              IDENT "vector"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "vector"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -2162,8 +2183,11 @@ SOURCE_FILE
                         COLON_COLON
                           COLON ":"
                           COLON ":"
-                        NAME_REF
-                          IDENT "vector"
+                        PATH_TYPE
+                          PATH
+                            PATH_SEGMENT
+                              NAME_REF
+                                IDENT "vector"
               R_PAREN ")"
     WHITESPACE "\n"
     LIMIT_CLAUSE
@@ -2557,8 +2581,11 @@ SOURCE_FILE
           COLON_COLON
             COLON ":"
             COLON ":"
-          NAME_REF
-            IDENT "date"
+          PATH_TYPE
+            PATH
+              PATH_SEGMENT
+                NAME_REF
+                  IDENT "date"
     WHITESPACE " "
     GROUP_BY_CLAUSE
       GROUP_KW "group"
@@ -3476,8 +3503,11 @@ SOURCE_FILE
                     COLON_COLON
                       COLON ":"
                       COLON ":"
-                    NAME_REF
-                      JSON_KW "json"
+                    PATH_TYPE
+                      PATH
+                        PATH_SEGMENT
+                          NAME_REF
+                            JSON_KW "json"
                   R_PAREN ")"
               WHITESPACE " "
               ALIAS
@@ -3511,8 +3541,11 @@ SOURCE_FILE
                       COLON_COLON
                         COLON ":"
                         COLON ":"
-                      NAME_REF
-                        JSON_KW "json"
+                      PATH_TYPE
+                        PATH
+                          PATH_SEGMENT
+                            NAME_REF
+                              JSON_KW "json"
                     R_PAREN ")"
                 WHITESPACE " "
                 ALIAS
@@ -3647,8 +3680,11 @@ SOURCE_FILE
                   COLON_COLON
                     COLON ":"
                     COLON ":"
-                  NAME_REF
-                    JSON_KW "json"
+                  PATH_TYPE
+                    PATH
+                      PATH_SEGMENT
+                        NAME_REF
+                          JSON_KW "json"
                 R_PAREN ")"
             WHITESPACE " "
             ALIAS
@@ -3692,8 +3728,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              IDENT "jsonb"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "jsonb"
           WHITESPACE "\n"
           R_PAREN ")"
   SEMICOLON ";"
@@ -5782,13 +5821,19 @@ SOURCE_FILE
                   COLON_COLON
                     COLON ":"
                     COLON ":"
-                  NAME_REF
-                    TEXT_KW "text"
+                  PATH_TYPE
+                    PATH
+                      PATH_SEGMENT
+                        NAME_REF
+                          TEXT_KW "text"
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                NAME_REF
-                  IDENT "float8"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "float8"
               COMMA ","
               WHITESPACE " "
               CAST_EXPR
@@ -5798,13 +5843,19 @@ SOURCE_FILE
                   COLON_COLON
                     COLON ":"
                     COLON ":"
-                  NAME_REF
-                    TEXT_KW "text"
+                  PATH_TYPE
+                    PATH
+                      PATH_SEGMENT
+                        NAME_REF
+                          TEXT_KW "text"
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                NAME_REF
-                  IDENT "float8"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "float8"
               R_PAREN ")"
     WHITESPACE " "
     FROM_CLAUSE

--- a/crates/squawk_parser/tests/snapshots/tests__select_casts_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_casts_ok.snap
@@ -12,8 +12,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              NUMERIC_KW "numeric"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NUMERIC_KW "numeric"
             WHITESPACE " "
             LITERAL
               STRING "'1234'"
@@ -31,8 +34,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              NUMERIC_KW "numeric"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NUMERIC_KW "numeric"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -85,14 +91,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              NAME_REF
-                BIT_KW "bit"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "3"
-                R_PAREN ")"
+            EXPR_TYPE
+              CALL_EXPR
+                NAME_REF
+                  BIT_KW "bit"
+                ARG_LIST
+                  L_PAREN "("
+                  LITERAL
+                    INT_NUMBER "3"
+                  R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -135,19 +142,53 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              CALL_EXPR
-                NAME_REF
-                  BIT_KW "bit"
-                ARG_LIST
-                  L_PAREN "("
-                  LITERAL
-                    INT_NUMBER "4"
-                  R_PAREN ")"
+              EXPR_TYPE
+                CALL_EXPR
+                  NAME_REF
+                    BIT_KW "bit"
+                  ARG_LIST
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "4"
+                    R_PAREN ")"
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTEGER_KW "integer"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTEGER_KW "integer"
+  SEMICOLON ";"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          CAST_EXPR
+            LITERAL
+              STRING "'{1}'"
+            COLON_COLON
+              COLON ":"
+              COLON ":"
+            EXPR_TYPE
+              INDEX_EXPR
+                CALL_EXPR
+                  FIELD_EXPR
+                    NAME_REF
+                      IDENT "pg_catalog"
+                    DOT "."
+                    NAME_REF
+                      VARCHAR_KW "varchar"
+                  ARG_LIST
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "1"
+                    R_PAREN ")"
+                L_BRACK "["
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -162,11 +203,12 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            INDEX_EXPR
-              NAME_REF
-                INT_KW "int"
-              L_BRACK "["
-              R_BRACK "]"
+            EXPR_TYPE
+              INDEX_EXPR
+                NAME_REF
+                  INT_KW "int"
+                L_BRACK "["
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -181,8 +223,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INT_KW "int"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INT_KW "int"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -197,11 +242,12 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            INDEX_EXPR
-              NAME_REF
-                NUMERIC_KW "numeric"
-              L_BRACK "["
-              R_BRACK "]"
+            EXPR_TYPE
+              INDEX_EXPR
+                NAME_REF
+                  NUMERIC_KW "numeric"
+                L_BRACK "["
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -220,33 +266,36 @@ SOURCE_FILE
                   COLON ":"
                   COLON ":"
                 WHITESPACE " "
-                INDEX_EXPR
-                  NAME_REF
-                    INT_KW "int"
-                  L_BRACK "["
-                  R_BRACK "]"
+                EXPR_TYPE
+                  INDEX_EXPR
+                    NAME_REF
+                      INT_KW "int"
+                    L_BRACK "["
+                    R_BRACK "]"
               WHITESPACE " "
               COLON_COLON
                 COLON ":"
                 COLON ":"
               WHITESPACE " "
-              INDEX_EXPR
-                NAME_REF
-                  IDENT "int8"
-                L_BRACK "["
-                R_BRACK "]"
+              EXPR_TYPE
+                INDEX_EXPR
+                  NAME_REF
+                    IDENT "int8"
+                  L_BRACK "["
+                  R_BRACK "]"
             WHITESPACE " "
             COLON_COLON
               COLON ":"
               COLON ":"
             WHITESPACE " "
-            INDEX_EXPR
-              NAME_REF
-                NUMERIC_KW "numeric"
-              L_BRACK "["
-              LITERAL
-                INT_NUMBER "1"
-              R_BRACK "]"
+            EXPR_TYPE
+              INDEX_EXPR
+                NAME_REF
+                  NUMERIC_KW "numeric"
+                L_BRACK "["
+                LITERAL
+                  INT_NUMBER "1"
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -263,29 +312,32 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                INDEX_EXPR
-                  NAME_REF
-                    INT_KW "int"
-                  L_BRACK "["
-                  R_BRACK "]"
+                EXPR_TYPE
+                  INDEX_EXPR
+                    NAME_REF
+                      INT_KW "int"
+                    L_BRACK "["
+                    R_BRACK "]"
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              INDEX_EXPR
-                NAME_REF
-                  IDENT "int8"
-                L_BRACK "["
-                R_BRACK "]"
+              EXPR_TYPE
+                INDEX_EXPR
+                  NAME_REF
+                    IDENT "int8"
+                  L_BRACK "["
+                  R_BRACK "]"
             COLON_COLON
               COLON ":"
               COLON ":"
-            INDEX_EXPR
-              NAME_REF
-                NUMERIC_KW "numeric"
-              L_BRACK "["
-              LITERAL
-                INT_NUMBER "1"
-              R_BRACK "]"
+            EXPR_TYPE
+              INDEX_EXPR
+                NAME_REF
+                  NUMERIC_KW "numeric"
+                L_BRACK "["
+                LITERAL
+                  INT_NUMBER "1"
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- based on postgres' gram.y"
@@ -304,10 +356,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              BIT_KW "bit"
-              WHITESPACE " "
-              VARYING_KW "varying"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    BIT_KW "bit"
+                    WHITESPACE " "
+                    VARYING_KW "varying"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -322,16 +377,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              NAME_REF
-                BIT_KW "bit"
-                WHITESPACE " "
-                VARYING_KW "varying"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "4"
-                R_PAREN ")"
+            EXPR_TYPE
+              CALL_EXPR
+                NAME_REF
+                  BIT_KW "bit"
+                  WHITESPACE " "
+                  VARYING_KW "varying"
+                ARG_LIST
+                  L_PAREN "("
+                  LITERAL
+                    INT_NUMBER "4"
+                  R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- Character"
@@ -348,8 +404,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              CHARACTER_KW "character"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    CHARACTER_KW "character"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -364,10 +423,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              CHARACTER_KW "character"
-              WHITESPACE " "
-              VARYING_KW "varying"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    CHARACTER_KW "character"
+                    WHITESPACE " "
+                    VARYING_KW "varying"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -382,8 +444,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              CHAR_KW "char"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    CHAR_KW "char"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -398,10 +463,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              CHAR_KW "char"
-              WHITESPACE " "
-              VARYING_KW "varying"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    CHAR_KW "char"
+                    WHITESPACE " "
+                    VARYING_KW "varying"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -416,8 +484,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              VARCHAR_KW "varchar"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    VARCHAR_KW "varchar"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -432,10 +503,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              NATIONAL_KW "national"
-              WHITESPACE " "
-              CHARACTER_KW "character"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NATIONAL_KW "national"
+                    WHITESPACE " "
+                    CHARACTER_KW "character"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -450,12 +524,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              NATIONAL_KW "national"
-              WHITESPACE " "
-              CHARACTER_KW "character"
-              WHITESPACE " "
-              VARYING_KW "varying"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NATIONAL_KW "national"
+                    WHITESPACE " "
+                    CHARACTER_KW "character"
+                    WHITESPACE " "
+                    VARYING_KW "varying"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -470,10 +547,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              NATIONAL_KW "national"
-              WHITESPACE " "
-              CHAR_KW "char"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NATIONAL_KW "national"
+                    WHITESPACE " "
+                    CHAR_KW "char"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -488,12 +568,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              NATIONAL_KW "national"
-              WHITESPACE " "
-              CHAR_KW "char"
-              WHITESPACE " "
-              VARYING_KW "varying"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NATIONAL_KW "national"
+                    WHITESPACE " "
+                    CHAR_KW "char"
+                    WHITESPACE " "
+                    VARYING_KW "varying"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -508,8 +591,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              NCHAR_KW "nchar"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NCHAR_KW "nchar"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -524,10 +610,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              NCHAR_KW "nchar"
-              WHITESPACE " "
-              VARYING_KW "varying"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NCHAR_KW "nchar"
+                    WHITESPACE " "
+                    VARYING_KW "varying"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -542,13 +631,14 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            INDEX_EXPR
-              NAME_REF
-                NCHAR_KW "nchar"
-                WHITESPACE " "
-                VARYING_KW "varying"
-              L_BRACK "["
-              R_BRACK "]"
+            EXPR_TYPE
+              INDEX_EXPR
+                NAME_REF
+                  NCHAR_KW "nchar"
+                  WHITESPACE " "
+                  VARYING_KW "varying"
+                L_BRACK "["
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- ConstDatetime"
@@ -565,12 +655,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIMESTAMP_KW "timestamp"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "2"
-              R_PAREN ")"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIMESTAMP_KW "timestamp"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "2"
+                    R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -585,18 +678,21 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIMESTAMP_KW "timestamp"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "2"
-              R_PAREN ")"
-              WHITESPACE " "
-              WITH_KW "with"
-              WHITESPACE " "
-              TIME_KW "time"
-              WHITESPACE " "
-              ZONE_KW "zone"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIMESTAMP_KW "timestamp"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "2"
+                    R_PAREN ")"
+                    WHITESPACE " "
+                    WITH_KW "with"
+                    WHITESPACE " "
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    ZONE_KW "zone"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -611,18 +707,21 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIMESTAMP_KW "timestamp"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "2"
-              R_PAREN ")"
-              WHITESPACE " "
-              WITHOUT_KW "without"
-              WHITESPACE " "
-              TIME_KW "time"
-              WHITESPACE " "
-              ZONE_KW "zone"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIMESTAMP_KW "timestamp"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "2"
+                    R_PAREN ")"
+                    WHITESPACE " "
+                    WITHOUT_KW "without"
+                    WHITESPACE " "
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    ZONE_KW "zone"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -637,8 +736,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIMESTAMP_KW "timestamp"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIMESTAMP_KW "timestamp"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -653,14 +755,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIMESTAMP_KW "timestamp"
-              WHITESPACE " "
-              WITH_KW "with"
-              WHITESPACE " "
-              TIME_KW "time"
-              WHITESPACE " "
-              ZONE_KW "zone"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIMESTAMP_KW "timestamp"
+                    WHITESPACE " "
+                    WITH_KW "with"
+                    WHITESPACE " "
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    ZONE_KW "zone"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -675,14 +780,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIMESTAMP_KW "timestamp"
-              WHITESPACE " "
-              WITHOUT_KW "without"
-              WHITESPACE " "
-              TIME_KW "time"
-              WHITESPACE " "
-              ZONE_KW "zone"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIMESTAMP_KW "timestamp"
+                    WHITESPACE " "
+                    WITHOUT_KW "without"
+                    WHITESPACE " "
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    ZONE_KW "zone"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -697,12 +805,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIME_KW "time"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "2"
-              R_PAREN ")"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIME_KW "time"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "2"
+                    R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -717,18 +828,21 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIME_KW "time"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "2"
-              R_PAREN ")"
-              WHITESPACE " "
-              WITH_KW "with"
-              WHITESPACE " "
-              TIME_KW "time"
-              WHITESPACE " "
-              ZONE_KW "zone"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIME_KW "time"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "2"
+                    R_PAREN ")"
+                    WHITESPACE " "
+                    WITH_KW "with"
+                    WHITESPACE " "
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    ZONE_KW "zone"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -743,18 +857,21 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIME_KW "time"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "2"
-              R_PAREN ")"
-              WHITESPACE " "
-              WITHOUT_KW "without"
-              WHITESPACE " "
-              TIME_KW "time"
-              WHITESPACE " "
-              ZONE_KW "zone"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIME_KW "time"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "2"
+                    R_PAREN ")"
+                    WHITESPACE " "
+                    WITHOUT_KW "without"
+                    WHITESPACE " "
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    ZONE_KW "zone"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -769,8 +886,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIME_KW "time"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIME_KW "time"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -785,14 +905,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIME_KW "time"
-              WHITESPACE " "
-              WITH_KW "with"
-              WHITESPACE " "
-              TIME_KW "time"
-              WHITESPACE " "
-              ZONE_KW "zone"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    WITH_KW "with"
+                    WHITESPACE " "
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    ZONE_KW "zone"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -807,14 +930,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              TIME_KW "time"
-              WHITESPACE " "
-              WITHOUT_KW "without"
-              WHITESPACE " "
-              TIME_KW "time"
-              WHITESPACE " "
-              ZONE_KW "zone"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    WITHOUT_KW "without"
+                    WHITESPACE " "
+                    TIME_KW "time"
+                    WHITESPACE " "
+                    ZONE_KW "zone"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- timestamp with time zone cast"
@@ -1018,8 +1144,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1034,10 +1163,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              YEAR_KW "year"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    YEAR_KW "year"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1052,10 +1184,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              MONTH_KW "month"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    MONTH_KW "month"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1070,12 +1205,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "0"
-              R_PAREN ")"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "0"
+                    R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1090,10 +1228,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              DAY_KW "day"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    DAY_KW "day"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1108,10 +1249,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              HOUR_KW "hour"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    HOUR_KW "hour"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1126,10 +1270,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              MINUTE_KW "minute"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    MINUTE_KW "minute"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1144,10 +1291,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              SECOND_KW "second"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    SECOND_KW "second"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1162,14 +1312,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              SECOND_KW "second"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "100"
-              R_PAREN ")"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    SECOND_KW "second"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "100"
+                    R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1184,14 +1337,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              YEAR_KW "year"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              MONTH_KW "month"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    YEAR_KW "year"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    MONTH_KW "month"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1206,14 +1362,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              DAY_KW "day"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              HOUR_KW "hour"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    DAY_KW "day"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    HOUR_KW "hour"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1228,14 +1387,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              DAY_KW "day"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              MINUTE_KW "minute"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    DAY_KW "day"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    MINUTE_KW "minute"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1250,14 +1412,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              DAY_KW "day"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              SECOND_KW "second"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    DAY_KW "day"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    SECOND_KW "second"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1272,18 +1437,21 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              DAY_KW "day"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              SECOND_KW "second"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "10"
-              R_PAREN ")"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    DAY_KW "day"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    SECOND_KW "second"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "10"
+                    R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1298,14 +1466,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              HOUR_KW "hour"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              MINUTE_KW "minute"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    HOUR_KW "hour"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    MINUTE_KW "minute"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1320,14 +1491,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              HOUR_KW "hour"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              SECOND_KW "second"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    HOUR_KW "hour"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    SECOND_KW "second"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1342,18 +1516,21 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              HOUR_KW "hour"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              SECOND_KW "second"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "10"
-              R_PAREN ")"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    HOUR_KW "hour"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    SECOND_KW "second"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "10"
+                    R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1368,14 +1545,17 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              MINUTE_KW "minute"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              SECOND_KW "second"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    MINUTE_KW "minute"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    SECOND_KW "second"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1390,18 +1570,21 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              WHITESPACE " "
-              MINUTE_KW "minute"
-              WHITESPACE " "
-              TO_KW "to"
-              WHITESPACE " "
-              SECOND_KW "second"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "10"
-              R_PAREN ")"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    WHITESPACE " "
+                    MINUTE_KW "minute"
+                    WHITESPACE " "
+                    TO_KW "to"
+                    WHITESPACE " "
+                    SECOND_KW "second"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "10"
+                    R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1416,12 +1599,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTERVAL_KW "interval"
-              L_PAREN "("
-              LITERAL
-                INT_NUMBER "10"
-              R_PAREN ")"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTERVAL_KW "interval"
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "10"
+                    R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- JsonType"
@@ -1438,8 +1624,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              JSON_KW "json"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    JSON_KW "json"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- jsonb type cast"
@@ -1457,8 +1646,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               AT "@"
@@ -1470,8 +1662,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- GenericType"
@@ -1488,42 +1683,44 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            FIELD_EXPR
-              NAME_REF
-                IDENT "foo"
-              DOT "."
-              NAME_REF
-                IDENT "bar"
-  SEMICOLON ";"
-  WHITESPACE "\n\n"
-  SELECT
-    SELECT_CLAUSE
-      SELECT_KW "select"
-      WHITESPACE " "
-      TARGET_LIST
-        TARGET
-          CAST_EXPR
-            LITERAL
-              STRING "''"
-            COLON_COLON
-              COLON ":"
-              COLON ":"
-            CALL_EXPR
+            EXPR_TYPE
               FIELD_EXPR
                 NAME_REF
                   IDENT "foo"
                 DOT "."
                 NAME_REF
                   IDENT "bar"
-              ARG_LIST
-                L_PAREN "("
-                NAME_REF
-                  IDENT "buzz"
-                COMMA ","
-                WHITESPACE " "
-                NAME_REF
-                  IDENT "bizz"
-                R_PAREN ")"
+  SEMICOLON ";"
+  WHITESPACE "\n\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          CAST_EXPR
+            LITERAL
+              STRING "''"
+            COLON_COLON
+              COLON ":"
+              COLON ":"
+            EXPR_TYPE
+              CALL_EXPR
+                FIELD_EXPR
+                  NAME_REF
+                    IDENT "foo"
+                  DOT "."
+                  NAME_REF
+                    IDENT "bar"
+                ARG_LIST
+                  L_PAREN "("
+                  NAME_REF
+                    IDENT "buzz"
+                  COMMA ","
+                  WHITESPACE " "
+                  NAME_REF
+                    IDENT "bizz"
+                  R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1538,8 +1735,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              VARCHAR_KW "varchar"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    VARCHAR_KW "varchar"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1554,39 +1754,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              NAME_REF
-                VARCHAR_KW "varchar"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "5"
-                R_PAREN ")"
-  SEMICOLON ";"
-  WHITESPACE "\n"
-  SELECT
-    SELECT_CLAUSE
-      SELECT_KW "select"
-      WHITESPACE " "
-      TARGET_LIST
-        TARGET
-          CAST_EXPR
-            LITERAL
-              STRING "''"
-            COLON_COLON
-              COLON ":"
-              COLON ":"
-            INDEX_EXPR
+            EXPR_TYPE
               CALL_EXPR
                 NAME_REF
                   VARCHAR_KW "varchar"
                 ARG_LIST
                   L_PAREN "("
                   LITERAL
-                    INT_NUMBER "255"
+                    INT_NUMBER "5"
                   R_PAREN ")"
-              L_BRACK "["
-              R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1601,13 +1777,40 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            INDEX_EXPR
-              NAME_REF
-                VARCHAR_KW "varchar"
-              L_BRACK "["
-              LITERAL
-                INT_NUMBER "5"
-              R_BRACK "]"
+            EXPR_TYPE
+              INDEX_EXPR
+                CALL_EXPR
+                  NAME_REF
+                    VARCHAR_KW "varchar"
+                  ARG_LIST
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "255"
+                    R_PAREN ")"
+                L_BRACK "["
+                R_BRACK "]"
+  SEMICOLON ";"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          CAST_EXPR
+            LITERAL
+              STRING "''"
+            COLON_COLON
+              COLON ":"
+              COLON ":"
+            EXPR_TYPE
+              INDEX_EXPR
+                NAME_REF
+                  VARCHAR_KW "varchar"
+                L_BRACK "["
+                LITERAL
+                  INT_NUMBER "5"
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -1622,17 +1825,45 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            INDEX_EXPR
+            EXPR_TYPE
+              INDEX_EXPR
+                CALL_EXPR
+                  NAME_REF
+                    IDENT "t"
+                  ARG_LIST
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "255"
+                    R_PAREN ")"
+                L_BRACK "["
+                R_BRACK "]"
+  SEMICOLON ";"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          CAST_EXPR
+            LITERAL
+              STRING "''"
+            COLON_COLON
+              COLON ":"
+              COLON ":"
+            EXPR_TYPE
               CALL_EXPR
-                NAME_REF
-                  IDENT "t"
+                FIELD_EXPR
+                  NAME_REF
+                    IDENT "foo"
+                  DOT "."
+                  NAME_REF
+                    IDENT "buzz"
                 ARG_LIST
                   L_PAREN "("
                   LITERAL
-                    INT_NUMBER "255"
+                    INT_NUMBER "5"
                   R_PAREN ")"
-              L_BRACK "["
-              R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1647,63 +1878,8 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              FIELD_EXPR
-                NAME_REF
-                  IDENT "foo"
-                DOT "."
-                NAME_REF
-                  IDENT "buzz"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "5"
-                R_PAREN ")"
-  SEMICOLON ";"
-  WHITESPACE "\n"
-  SELECT
-    SELECT_CLAUSE
-      SELECT_KW "select"
-      WHITESPACE " "
-      TARGET_LIST
-        TARGET
-          CAST_EXPR
-            LITERAL
-              STRING "''"
-            COLON_COLON
-              COLON ":"
-              COLON ":"
-            INDEX_EXPR
-              FIELD_EXPR
-                FIELD_EXPR
-                  NAME_REF
-                    IDENT "bar"
-                  DOT "."
-                  NAME_REF
-                    IDENT "foo"
-                DOT "."
-                NAME_REF
-                  IDENT "buzz"
-              L_BRACK "["
-              LITERAL
-                INT_NUMBER "5"
-              R_BRACK "]"
-  SEMICOLON ";"
-  WHITESPACE "\n"
-  SELECT
-    SELECT_CLAUSE
-      SELECT_KW "select"
-      WHITESPACE " "
-      TARGET_LIST
-        TARGET
-          CAST_EXPR
-            LITERAL
-              STRING "''"
-            COLON_COLON
-              COLON ":"
-              COLON ":"
-            INDEX_EXPR
-              CALL_EXPR
+            EXPR_TYPE
+              INDEX_EXPR
                 FIELD_EXPR
                   FIELD_EXPR
                     NAME_REF
@@ -1714,13 +1890,44 @@ SOURCE_FILE
                   DOT "."
                   NAME_REF
                     IDENT "buzz"
-                ARG_LIST
-                  L_PAREN "("
-                  LITERAL
-                    INT_NUMBER "255"
-                  R_PAREN ")"
-              L_BRACK "["
-              R_BRACK "]"
+                L_BRACK "["
+                LITERAL
+                  INT_NUMBER "5"
+                R_BRACK "]"
+  SEMICOLON ";"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          CAST_EXPR
+            LITERAL
+              STRING "''"
+            COLON_COLON
+              COLON ":"
+              COLON ":"
+            EXPR_TYPE
+              INDEX_EXPR
+                CALL_EXPR
+                  FIELD_EXPR
+                    FIELD_EXPR
+                      NAME_REF
+                        IDENT "bar"
+                      DOT "."
+                      NAME_REF
+                        IDENT "foo"
+                    DOT "."
+                    NAME_REF
+                      IDENT "buzz"
+                  ARG_LIST
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "255"
+                    R_PAREN ")"
+                L_BRACK "["
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- Numeric"
@@ -1737,8 +1944,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INT_KW "int"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INT_KW "int"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1753,8 +1963,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTEGER_KW "integer"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTEGER_KW "integer"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1769,8 +1982,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              SMALLINT_KW "smallint"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    SMALLINT_KW "smallint"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1785,8 +2001,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              BIGINT_KW "bigint"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    BIGINT_KW "bigint"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1801,8 +2020,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              FLOAT_KW "float"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    FLOAT_KW "float"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1817,14 +2039,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              NAME_REF
-                FLOAT_KW "float"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "1"
-                R_PAREN ")"
+            EXPR_TYPE
+              CALL_EXPR
+                NAME_REF
+                  FLOAT_KW "float"
+                ARG_LIST
+                  L_PAREN "("
+                  LITERAL
+                    INT_NUMBER "1"
+                  R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1839,10 +2062,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              DOUBLE_KW "double"
-              WHITESPACE " "
-              PRECISION_KW "precision"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    DOUBLE_KW "double"
+                    WHITESPACE " "
+                    PRECISION_KW "precision"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1857,8 +2083,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              DECIMAL_KW "decimal"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    DECIMAL_KW "decimal"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1873,22 +2102,23 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              NAME_REF
-                DECIMAL_KW "decimal"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "1"
-                COMMA ","
-                WHITESPACE " "
-                LITERAL
-                  INT_NUMBER "2"
-                COMMA ","
-                WHITESPACE " "
-                LITERAL
-                  INT_NUMBER "3"
-                R_PAREN ")"
+            EXPR_TYPE
+              CALL_EXPR
+                NAME_REF
+                  DECIMAL_KW "decimal"
+                ARG_LIST
+                  L_PAREN "("
+                  LITERAL
+                    INT_NUMBER "1"
+                  COMMA ","
+                  WHITESPACE " "
+                  LITERAL
+                    INT_NUMBER "2"
+                  COMMA ","
+                  WHITESPACE " "
+                  LITERAL
+                    INT_NUMBER "3"
+                  R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1903,8 +2133,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              DEC_KW "dec"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    DEC_KW "dec"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1919,22 +2152,23 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              NAME_REF
-                DEC_KW "dec"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "1"
-                COMMA ","
-                WHITESPACE " "
-                LITERAL
-                  INT_NUMBER "2"
-                COMMA ","
-                WHITESPACE " "
-                LITERAL
-                  INT_NUMBER "3"
-                R_PAREN ")"
+            EXPR_TYPE
+              CALL_EXPR
+                NAME_REF
+                  DEC_KW "dec"
+                ARG_LIST
+                  L_PAREN "("
+                  LITERAL
+                    INT_NUMBER "1"
+                  COMMA ","
+                  WHITESPACE " "
+                  LITERAL
+                    INT_NUMBER "2"
+                  COMMA ","
+                  WHITESPACE " "
+                  LITERAL
+                    INT_NUMBER "3"
+                  R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1949,8 +2183,11 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              NUMERIC_KW "numeric"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NUMERIC_KW "numeric"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -1965,64 +2202,69 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              NAME_REF
-                NUMERIC_KW "numeric"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "1"
-                COMMA ","
-                WHITESPACE " "
-                LITERAL
-                  INT_NUMBER "2"
-                R_PAREN ")"
-  SEMICOLON ";"
-  WHITESPACE "\n"
-  SELECT
-    SELECT_CLAUSE
-      SELECT_KW "select"
-      WHITESPACE " "
-      TARGET_LIST
-        TARGET
-          CAST_EXPR
-            LITERAL
-              STRING "''"
-            COLON_COLON
-              COLON ":"
-              COLON ":"
-            NAME_REF
-              BOOLEAN_KW "boolean"
-  SEMICOLON ";"
-  WHITESPACE "\n"
-  SELECT
-    SELECT_CLAUSE
-      SELECT_KW "select"
-      WHITESPACE " "
-      TARGET_LIST
-        TARGET
-          CAST_EXPR
-            LITERAL
-              STRING "''"
-            COLON_COLON
-              COLON ":"
-              COLON ":"
-            INDEX_EXPR
+            EXPR_TYPE
               CALL_EXPR
                 NAME_REF
                   NUMERIC_KW "numeric"
                 ARG_LIST
                   L_PAREN "("
                   LITERAL
-                    INT_NUMBER "10"
+                    INT_NUMBER "1"
                   COMMA ","
+                  WHITESPACE " "
                   LITERAL
                     INT_NUMBER "2"
                   R_PAREN ")"
-              L_BRACK "["
-              LITERAL
-                INT_NUMBER "10"
-              R_BRACK "]"
+  SEMICOLON ";"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          CAST_EXPR
+            LITERAL
+              STRING "''"
+            COLON_COLON
+              COLON ":"
+              COLON ":"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    BOOLEAN_KW "boolean"
+  SEMICOLON ";"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          CAST_EXPR
+            LITERAL
+              STRING "''"
+            COLON_COLON
+              COLON ":"
+              COLON ":"
+            EXPR_TYPE
+              INDEX_EXPR
+                CALL_EXPR
+                  NAME_REF
+                    NUMERIC_KW "numeric"
+                  ARG_LIST
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "10"
+                    COMMA ","
+                    LITERAL
+                      INT_NUMBER "2"
+                    R_PAREN ")"
+                L_BRACK "["
+                LITERAL
+                  INT_NUMBER "10"
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n\n"
   COMMENT "-- interval_cast_trailing"
@@ -2350,14 +2592,15 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              CALL_EXPR
-                NAME_REF
-                  CHAR_KW "char"
-                ARG_LIST
-                  L_PAREN "("
-                  LITERAL
-                    INT_NUMBER "1"
-                  R_PAREN ")"
+              EXPR_TYPE
+                CALL_EXPR
+                  NAME_REF
+                    CHAR_KW "char"
+                  ARG_LIST
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "1"
+                    R_PAREN ")"
             WHITESPACE " "
             COLLATE_KW "collate"
             WHITESPACE " "
@@ -2379,14 +2622,15 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                CALL_EXPR
-                  NAME_REF
-                    CHAR_KW "CHAR"
-                  ARG_LIST
-                    L_PAREN "("
-                    LITERAL
-                      INT_NUMBER "2"
-                    R_PAREN ")"
+                EXPR_TYPE
+                  CALL_EXPR
+                    NAME_REF
+                      CHAR_KW "CHAR"
+                    ARG_LIST
+                      L_PAREN "("
+                      LITERAL
+                        INT_NUMBER "2"
+                      R_PAREN ")"
               WHITESPACE " "
               COLLATE_KW "collate"
               WHITESPACE " "
@@ -2401,14 +2645,15 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              CALL_EXPR
-                NAME_REF
-                  CHAR_KW "CHAR"
-                ARG_LIST
-                  L_PAREN "("
-                  LITERAL
-                    INT_NUMBER "2"
-                  R_PAREN ")"
+              EXPR_TYPE
+                CALL_EXPR
+                  NAME_REF
+                    CHAR_KW "CHAR"
+                  ARG_LIST
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "2"
+                    R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -2571,34 +2816,35 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            INDEX_EXPR
+            EXPR_TYPE
               INDEX_EXPR
                 INDEX_EXPR
                   INDEX_EXPR
                     INDEX_EXPR
                       INDEX_EXPR
-                        NAME_REF
-                          INTEGER_KW "integer"
+                        INDEX_EXPR
+                          NAME_REF
+                            INTEGER_KW "integer"
+                          L_BRACK "["
+                          LITERAL
+                            INT_NUMBER "1"
+                          R_BRACK "]"
                         L_BRACK "["
                         LITERAL
-                          INT_NUMBER "1"
+                          INT_NUMBER "2"
                         R_BRACK "]"
                       L_BRACK "["
                       LITERAL
-                        INT_NUMBER "2"
+                        INT_NUMBER "3"
                       R_BRACK "]"
                     L_BRACK "["
-                    LITERAL
-                      INT_NUMBER "3"
                     R_BRACK "]"
                   L_BRACK "["
                   R_BRACK "]"
                 L_BRACK "["
+                LITERAL
+                  INT_NUMBER "1000"
                 R_BRACK "]"
-              L_BRACK "["
-              LITERAL
-                INT_NUMBER "1000"
-              R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -2615,11 +2861,12 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            INDEX_EXPR
-              NAME_REF
-                INTEGER_KW "integer"
-              L_BRACK "["
-              R_BRACK "]"
+            EXPR_TYPE
+              INDEX_EXPR
+                NAME_REF
+                  INTEGER_KW "integer"
+                L_BRACK "["
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- casts"
@@ -2636,14 +2883,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              NAME_REF
-                BIT_KW "bit"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "10"
-                R_PAREN ")"
+            EXPR_TYPE
+              CALL_EXPR
+                NAME_REF
+                  BIT_KW "bit"
+                ARG_LIST
+                  L_PAREN "("
+                  LITERAL
+                    INT_NUMBER "10"
+                  R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE " "
   COMMENT "-- 0000101100"
@@ -2660,14 +2908,15 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            CALL_EXPR
-              NAME_REF
-                BIT_KW "bit"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "3"
-                R_PAREN ")"
+            EXPR_TYPE
+              CALL_EXPR
+                NAME_REF
+                  BIT_KW "bit"
+                ARG_LIST
+                  L_PAREN "("
+                  LITERAL
+                    INT_NUMBER "3"
+                  R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE " "
   COMMENT "-- 100"
@@ -2714,19 +2963,23 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              CALL_EXPR
-                NAME_REF
-                  BIT_KW "bit"
-                ARG_LIST
-                  L_PAREN "("
-                  LITERAL
-                    INT_NUMBER "4"
-                  R_PAREN ")"
+              EXPR_TYPE
+                CALL_EXPR
+                  NAME_REF
+                    BIT_KW "bit"
+                  ARG_LIST
+                    L_PAREN "("
+                    LITERAL
+                      INT_NUMBER "4"
+                    R_PAREN ")"
             COLON_COLON
               COLON ":"
               COLON ":"
-            NAME_REF
-              INTEGER_KW "integer"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTEGER_KW "integer"
   SEMICOLON ";"
   WHITESPACE " "
   COMMENT "-- 14"
@@ -2743,12 +2996,13 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            FIELD_EXPR
-              NAME_REF
-                IDENT "pg_catalog"
-              DOT "."
-              NAME_REF
-                IDENT "int8"
+            EXPR_TYPE
+              FIELD_EXPR
+                NAME_REF
+                  IDENT "pg_catalog"
+                DOT "."
+                NAME_REF
+                  IDENT "int8"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -2763,15 +3017,16 @@ SOURCE_FILE
             COLON_COLON
               COLON ":"
               COLON ":"
-            INDEX_EXPR
-              FIELD_EXPR
-                NAME_REF
-                  IDENT "pg_catalog"
-                DOT "."
-                NAME_REF
-                  IDENT "int8"
-              L_BRACK "["
-              R_BRACK "]"
+            EXPR_TYPE
+              INDEX_EXPR
+                FIELD_EXPR
+                  NAME_REF
+                    IDENT "pg_catalog"
+                  DOT "."
+                  NAME_REF
+                    IDENT "int8"
+                L_BRACK "["
+                R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n\n\n"
   COMMENT "-- cast"
@@ -2802,7 +3057,43 @@ SOURCE_FILE
                     IDENT "bar"
             R_PAREN ")"
   SEMICOLON ";"
-  WHITESPACE "\n\n"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          CAST_EXPR
+            CAST_KW "cast"
+            L_PAREN "("
+            LITERAL
+              STRING "'{1}'"
+            WHITESPACE " "
+            AS_KW "as"
+            WHITESPACE " "
+            ARRAY_TYPE
+              PATH_TYPE
+                PATH
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "pg_catalog"
+                  DOT "."
+                  PATH_SEGMENT
+                    NAME_REF
+                      VARCHAR_KW "varchar"
+                ARG_LIST
+                  L_PAREN "("
+                  ARG
+                    LITERAL
+                      INT_NUMBER "1"
+                  R_PAREN ")"
+              L_BRACK "["
+              R_BRACK "]"
+            R_PAREN ")"
+  SEMICOLON ";"
+  WHITESPACE "\n\n\n"
   COMMENT "-- treat"
   WHITESPACE "\n"
   SELECT
@@ -2863,8 +3154,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              JSON_KW "json"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    JSON_KW "json"
             WHITESPACE " "
             LITERAL
               STRING "'{}'"
@@ -3423,8 +3717,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              INT_KW "int"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INT_KW "int"
             WHITESPACE " "
             LITERAL
               STRING "''"
@@ -3437,8 +3734,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              INTEGER_KW "integer"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    INTEGER_KW "integer"
             WHITESPACE " "
             LITERAL
               STRING "''"
@@ -3451,8 +3751,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              SMALLINT_KW "smallint"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    SMALLINT_KW "smallint"
             WHITESPACE " "
             LITERAL
               STRING "''"
@@ -3465,8 +3768,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              BIGINT_KW "bigint"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    BIGINT_KW "bigint"
             WHITESPACE " "
             LITERAL
               STRING "''"
@@ -3479,8 +3785,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              REAL_KW "real"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    REAL_KW "real"
             WHITESPACE " "
             LITERAL
               STRING "''"
@@ -3493,8 +3802,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              FLOAT_KW "float"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    FLOAT_KW "float"
             WHITESPACE " "
             LITERAL
               STRING "''"
@@ -3567,8 +3879,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              DECIMAL_KW "decimal"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    DECIMAL_KW "decimal"
             WHITESPACE " "
             LITERAL
               STRING "'10'"
@@ -3605,8 +3920,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              DEC_KW "dec"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    DEC_KW "dec"
             WHITESPACE " "
             LITERAL
               STRING "'10'"
@@ -3643,8 +3961,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              NUMERIC_KW "numeric"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    NUMERIC_KW "numeric"
             WHITESPACE " "
             LITERAL
               STRING "'10'"
@@ -3657,8 +3978,11 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            NAME_REF
-              BOOLEAN_KW "boolean"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    BOOLEAN_KW "boolean"
             WHITESPACE " "
             LITERAL
               STRING "'false'"
@@ -3671,12 +3995,13 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            FIELD_EXPR
-              NAME_REF
-                IDENT "foo"
-              DOT "."
-              NAME_REF
-                IDENT "bar"
+            EXPR_TYPE
+              FIELD_EXPR
+                NAME_REF
+                  IDENT "foo"
+                DOT "."
+                NAME_REF
+                  IDENT "bar"
             WHITESPACE " "
             LITERAL
               STRING "'100'"
@@ -3689,24 +4014,50 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            CALL_EXPR
-              FIELD_EXPR
-                NAME_REF
-                  IDENT "foo"
-                DOT "."
-                NAME_REF
-                  IDENT "bar"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "10"
-                COMMA ","
-                WHITESPACE " "
-                LITERAL
-                  INT_NUMBER "2"
-                R_PAREN ")"
+            EXPR_TYPE
+              CALL_EXPR
+                FIELD_EXPR
+                  NAME_REF
+                    IDENT "foo"
+                  DOT "."
+                  NAME_REF
+                    IDENT "bar"
+                ARG_LIST
+                  L_PAREN "("
+                  LITERAL
+                    INT_NUMBER "10"
+                  COMMA ","
+                  WHITESPACE " "
+                  LITERAL
+                    INT_NUMBER "2"
+                  R_PAREN ")"
             WHITESPACE " "
             LITERAL
               STRING "'100'"
+  SEMICOLON ";"
+  WHITESPACE "\n"
+  SELECT
+    SELECT_CLAUSE
+      SELECT_KW "select"
+      WHITESPACE " "
+      TARGET_LIST
+        TARGET
+          CAST_EXPR
+            EXPR_TYPE
+              CALL_EXPR
+                FIELD_EXPR
+                  NAME_REF
+                    IDENT "pg_catalog"
+                  DOT "."
+                  NAME_REF
+                    VARCHAR_KW "varchar"
+                ARG_LIST
+                  L_PAREN "("
+                  LITERAL
+                    INT_NUMBER "100"
+                  R_PAREN ")"
+            WHITESPACE " "
+            LITERAL
+              STRING "'{123}'"
   SEMICOLON ";"
   WHITESPACE "\n"

--- a/crates/squawk_parser/tests/snapshots/tests__select_casts_pg17_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_casts_pg17_ok.snap
@@ -10,27 +10,28 @@ SOURCE_FILE
       TARGET_LIST
         TARGET
           CAST_EXPR
-            CALL_EXPR
-              FIELD_EXPR
-                INDEX_EXPR
+            EXPR_TYPE
+              CALL_EXPR
+                FIELD_EXPR
+                  INDEX_EXPR
+                    NAME_REF
+                      IDENT "foo"
+                    L_BRACK "["
+                    LITERAL
+                      INT_NUMBER "10"
+                    R_BRACK "]"
+                  DOT "."
                   NAME_REF
-                    IDENT "foo"
-                  L_BRACK "["
+                    IDENT "bar"
+                ARG_LIST
+                  L_PAREN "("
                   LITERAL
                     INT_NUMBER "10"
-                  R_BRACK "]"
-                DOT "."
-                NAME_REF
-                  IDENT "bar"
-              ARG_LIST
-                L_PAREN "("
-                LITERAL
-                  INT_NUMBER "10"
-                COMMA ","
-                WHITESPACE " "
-                LITERAL
-                  INT_NUMBER "2"
-                R_PAREN ")"
+                  COMMA ","
+                  WHITESPACE " "
+                  LITERAL
+                    INT_NUMBER "2"
+                  R_PAREN ")"
             WHITESPACE " "
             LITERAL
               STRING "'100'"

--- a/crates/squawk_parser/tests/snapshots/tests__select_compound_union_select_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_compound_union_select_ok.snap
@@ -49,14 +49,15 @@ SOURCE_FILE
                           COLON_COLON
                             COLON ":"
                             COLON ":"
-                          CALL_EXPR
-                            NAME_REF
-                              CHAR_KW "char"
-                            ARG_LIST
-                              L_PAREN "("
-                              LITERAL
-                                INT_NUMBER "4"
-                              R_PAREN ")"
+                          EXPR_TYPE
+                            CALL_EXPR
+                              NAME_REF
+                                CHAR_KW "char"
+                              ARG_LIST
+                                L_PAREN "("
+                                LITERAL
+                                  INT_NUMBER "4"
+                                R_PAREN ")"
                   WHITESPACE " "
                   ORDER_BY_CLAUSE
                     ORDER_KW "ORDER"
@@ -187,14 +188,15 @@ SOURCE_FILE
                           COLON_COLON
                             COLON ":"
                             COLON ":"
-                          CALL_EXPR
-                            NAME_REF
-                              CHAR_KW "char"
-                            ARG_LIST
-                              L_PAREN "("
-                              LITERAL
-                                INT_NUMBER "4"
-                              R_PAREN ")"
+                          EXPR_TYPE
+                            CALL_EXPR
+                              NAME_REF
+                                CHAR_KW "char"
+                              ARG_LIST
+                                L_PAREN "("
+                                LITERAL
+                                  INT_NUMBER "4"
+                                R_PAREN ")"
                   WHITESPACE " "
                   ORDER_BY_CLAUSE
                     ORDER_KW "ORDER"

--- a/crates/squawk_parser/tests/snapshots/tests__select_funcs_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_funcs_ok.snap
@@ -2127,8 +2127,11 @@ SOURCE_FILE
               COMMA ","
               WHITESPACE " "
               CAST_EXPR
-                NAME_REF
-                  JSON_KW "json"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        JSON_KW "json"
                 WHITESPACE " "
                 LITERAL
                   STRING "'{\"a\":null}'"
@@ -2932,8 +2935,11 @@ SOURCE_FILE
               FROM_KW "from"
               WHITESPACE " "
               CAST_EXPR
-                NAME_REF
-                  IDENT "timestamptz"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "timestamptz"
                 WHITESPACE " "
                 LITERAL
                   STRING "'2013-07-01 12:00:00'"
@@ -3004,8 +3010,11 @@ SOURCE_FILE
               FROM_KW "from"
               WHITESPACE " "
               CAST_EXPR
-                NAME_REF
-                  IDENT "date"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "date"
                 WHITESPACE " "
                 LITERAL
                   STRING "'2006-01-01'"
@@ -3028,8 +3037,11 @@ SOURCE_FILE
               FROM_KW "from"
               WHITESPACE " "
               CAST_EXPR
-                NAME_REF
-                  IDENT "date"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "date"
                 WHITESPACE " "
                 LITERAL
                   STRING "'2006-01-01'"
@@ -3661,11 +3673,12 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                INDEX_EXPR
-                  NAME_REF
-                    NUMERIC_KW "numeric"
-                  L_BRACK "["
-                  R_BRACK "]"
+                EXPR_TYPE
+                  INDEX_EXPR
+                    NAME_REF
+                      NUMERIC_KW "numeric"
+                    L_BRACK "["
+                    R_BRACK "]"
               R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"

--- a/crates/squawk_parser/tests/snapshots/tests__select_funcs_pg17_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_funcs_pg17_ok.snap
@@ -431,8 +431,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                JSON_KW "json"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      JSON_KW "json"
             COMMA ","
             WHITESPACE " "
             LITERAL
@@ -1020,8 +1023,11 @@ SOURCE_FILE
             ARG_LIST
               L_PAREN "("
               CAST_EXPR
-                NAME_REF
-                  IDENT "jsonb"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "jsonb"
                 WHITESPACE " "
                 LITERAL
                   STRING "'{\"key1\": [1,2,3]}'"
@@ -1056,8 +1062,11 @@ SOURCE_FILE
             ARG_LIST
               L_PAREN "("
               CAST_EXPR
-                NAME_REF
-                  IDENT "jsonb"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "jsonb"
                 WHITESPACE " "
                 LITERAL
                   STRING "'{\"a\": [1,2,3]}'"
@@ -1088,8 +1097,11 @@ SOURCE_FILE
             ARG_LIST
               L_PAREN "("
               CAST_EXPR
-                NAME_REF
-                  IDENT "jsonb"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "jsonb"
                 WHITESPACE " "
                 LITERAL
                   STRING "'{\"a\": [1,2,3]}'"

--- a/crates/squawk_parser/tests/snapshots/tests__select_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_ok.snap
@@ -6037,8 +6037,11 @@ SOURCE_FILE
           GTEQ ">="
           WHITESPACE " "
           CAST_EXPR
-            NAME_REF
-              IDENT "DATE"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "DATE"
             WHITESPACE " "
             LITERAL
               STRING "'2023-12-21'"
@@ -6052,8 +6055,11 @@ SOURCE_FILE
           L_ANGLE "<"
           WHITESPACE " "
           CAST_EXPR
-            NAME_REF
-              IDENT "DATE"
+            PATH_TYPE
+              PATH
+                PATH_SEGMENT
+                  NAME_REF
+                    IDENT "DATE"
             WHITESPACE " "
             LITERAL
               STRING "'2023-12-22'"

--- a/crates/squawk_parser/tests/snapshots/tests__select_operators_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_operators_ok.snap
@@ -105,8 +105,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(1,1),(0,0)'"
@@ -114,8 +117,11 @@ SOURCE_FILE
             PLUS "+"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,0)'"
@@ -131,8 +137,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                PATH_KW "path"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      PATH_KW "path"
               WHITESPACE " "
               LITERAL
                 STRING "'[(0,0),(1,1)]'"
@@ -140,8 +149,11 @@ SOURCE_FILE
             PLUS "+"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                PATH_KW "path"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      PATH_KW "path"
               WHITESPACE " "
               LITERAL
                 STRING "'[(2,2),(3,3),(4,4)]'"
@@ -157,8 +169,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(1,1),(0,0)'"
@@ -166,8 +181,11 @@ SOURCE_FILE
             MINUS "-"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,0)'"
@@ -183,8 +201,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                PATH_KW "path"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      PATH_KW "path"
               WHITESPACE " "
               LITERAL
                 STRING "'((0,0),(1,0),(1,1))'"
@@ -192,8 +213,11 @@ SOURCE_FILE
             STAR "*"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(3.0,0)'"
@@ -207,8 +231,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                PATH_KW "path"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      PATH_KW "path"
               WHITESPACE " "
               LITERAL
                 STRING "'((0,0),(1,0),(1,1))'"
@@ -251,8 +278,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                PATH_KW "path"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      PATH_KW "path"
               WHITESPACE " "
               LITERAL
                 STRING "'((0,0),(1,0),(1,1))'"
@@ -260,8 +290,11 @@ SOURCE_FILE
             SLASH "/"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(2.0,0)'"
@@ -275,8 +308,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                PATH_KW "path"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      PATH_KW "path"
               WHITESPACE " "
               LITERAL
                 STRING "'((0,0),(1,0),(1,1))'"
@@ -324,8 +360,11 @@ SOURCE_FILE
               AT "@"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                PATH_KW "path"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      PATH_KW "path"
               WHITESPACE " "
               LITERAL
                 STRING "'[(0,0),(1,0),(1,1)]'"
@@ -345,8 +384,11 @@ SOURCE_FILE
               AT "@"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,2),(0,0)'"
@@ -365,8 +407,11 @@ SOURCE_FILE
               POUND "#"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                PATH_KW "path"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      PATH_KW "path"
               WHITESPACE " "
               LITERAL
                 STRING "'((1,0),(0,1),(-1,0))'"
@@ -382,8 +427,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(0,0),(1,1)]'"
@@ -392,8 +440,11 @@ SOURCE_FILE
               POUND "#"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(1,0),(0,1)]'"
@@ -409,8 +460,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,2),(-1,-1)'"
@@ -419,8 +473,11 @@ SOURCE_FILE
               POUND "#"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(1,1),(-2,-2)'"
@@ -436,8 +493,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(0,0)'"
@@ -447,8 +507,11 @@ SOURCE_FILE
               POUND "#"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(2,0),(0,2)]'"
@@ -464,8 +527,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "circle"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "circle"
               WHITESPACE " "
               LITERAL
                 STRING "'<(0,0),1>'"
@@ -476,8 +542,11 @@ SOURCE_FILE
               R_ANGLE ">"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "circle"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "circle"
               WHITESPACE " "
               LITERAL
                 STRING "'<(5,0),1>'"
@@ -493,8 +562,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "circle"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "circle"
               WHITESPACE " "
               LITERAL
                 STRING "'<(0,0),2>'"
@@ -504,8 +576,11 @@ SOURCE_FILE
               R_ANGLE ">"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(1,1)'"
@@ -521,8 +596,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(1,1)'"
@@ -532,8 +610,11 @@ SOURCE_FILE
               AT "@"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "circle"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "circle"
               WHITESPACE " "
               LITERAL
                 STRING "'<(0,0),2>'"
@@ -549,8 +630,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(1,1),(0,0)'"
@@ -560,8 +644,11 @@ SOURCE_FILE
               AMP "&"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,2),(0,0)'"
@@ -577,8 +664,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "circle"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "circle"
               WHITESPACE " "
               LITERAL
                 STRING "'<(0,0),1>'"
@@ -588,8 +678,11 @@ SOURCE_FILE
               L_ANGLE "<"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "circle"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "circle"
               WHITESPACE " "
               LITERAL
                 STRING "'<(5,0),1>'"
@@ -605,8 +698,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "circle"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "circle"
               WHITESPACE " "
               LITERAL
                 STRING "'<(5,0),1>'"
@@ -616,8 +712,11 @@ SOURCE_FILE
               R_ANGLE ">"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "circle"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "circle"
               WHITESPACE " "
               LITERAL
                 STRING "'<(0,0),1>'"
@@ -633,8 +732,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(1,1),(0,0)'"
@@ -644,8 +746,11 @@ SOURCE_FILE
               L_ANGLE "<"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,2),(0,0)'"
@@ -661,8 +766,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(3,3),(0,0)'"
@@ -672,8 +780,11 @@ SOURCE_FILE
               R_ANGLE ">"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,2),(0,0)'"
@@ -689,8 +800,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(3,3),(0,0)'"
@@ -701,8 +815,11 @@ SOURCE_FILE
               PIPE "|"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(5,5),(3,4)'"
@@ -718,8 +835,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(3,3),(0,0)'"
@@ -730,8 +850,11 @@ SOURCE_FILE
               R_ANGLE ">"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(5,5),(3,4)'"
@@ -747,8 +870,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(1,1),(0,0)'"
@@ -759,8 +885,11 @@ SOURCE_FILE
               PIPE "|"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,2),(0,0)'"
@@ -776,8 +905,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(3,3),(0,0)'"
@@ -788,8 +920,11 @@ SOURCE_FILE
               R_ANGLE ">"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,2),(0,0)'"
@@ -805,8 +940,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'((1,1),(0,0))'"
@@ -816,8 +954,11 @@ SOURCE_FILE
               CARET "^"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'((2,2),(1,1))'"
@@ -833,8 +974,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'((2,2),(1,1))'"
@@ -844,8 +988,11 @@ SOURCE_FILE
               CARET "^"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'((1,1),(0,0))'"
@@ -861,8 +1008,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(-1,0),(1,0)]'"
@@ -872,8 +1022,11 @@ SOURCE_FILE
               POUND "#"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "box"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "box"
               WHITESPACE " "
               LITERAL
                 STRING "'(2,2),(-2,-2)'"
@@ -893,8 +1046,11 @@ SOURCE_FILE
               MINUS "-"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(-1,0),(1,0)]'"
@@ -910,8 +1066,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(1,0)'"
@@ -921,8 +1080,11 @@ SOURCE_FILE
               MINUS "-"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(0,0)'"
@@ -942,8 +1104,11 @@ SOURCE_FILE
               PIPE "|"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(-1,0),(1,0)]'"
@@ -959,8 +1124,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(0,1)'"
@@ -970,8 +1138,11 @@ SOURCE_FILE
               PIPE "|"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "point"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "point"
               WHITESPACE " "
               LITERAL
                 STRING "'(0,0)'"
@@ -987,8 +1158,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(0,0),(0,1)]'"
@@ -999,8 +1173,11 @@ SOURCE_FILE
               PIPE "|"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(0,0),(1,0)]'"
@@ -1016,8 +1193,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(-1,0),(1,0)]'"
@@ -1028,8 +1208,11 @@ SOURCE_FILE
               PIPE "|"
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "lseg"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "lseg"
               WHITESPACE " "
               LITERAL
                 STRING "'[(-1,2),(1,2)]'"
@@ -1045,8 +1228,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "polygon"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "polygon"
               WHITESPACE " "
               LITERAL
                 STRING "'((0,0),(1,1))'"
@@ -1056,8 +1242,11 @@ SOURCE_FILE
               EQ "="
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "polygon"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "polygon"
               WHITESPACE " "
               LITERAL
                 STRING "'((1,1),(0,0))'"
@@ -1075,8 +1264,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "inet"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "inet"
               WHITESPACE " "
               LITERAL
                 STRING "'192.168.1/24'"
@@ -1087,8 +1279,11 @@ SOURCE_FILE
               EQ "="
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "inet"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "inet"
               WHITESPACE " "
               LITERAL
                 STRING "'192.168.1/24'"
@@ -1104,8 +1299,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "inet"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "inet"
               WHITESPACE " "
               LITERAL
                 STRING "'192.168.1/24'"
@@ -1116,8 +1314,11 @@ SOURCE_FILE
               EQ "="
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "inet"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "inet"
               WHITESPACE " "
               LITERAL
                 STRING "'192.168.1/24'"
@@ -1144,8 +1345,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "tsquery"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "tsquery"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- subnet contain or equal subnet"
@@ -1158,8 +1362,11 @@ SOURCE_FILE
         TARGET
           BIN_EXPR
             CAST_EXPR
-              NAME_REF
-                IDENT "inet"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "inet"
               WHITESPACE " "
               LITERAL
                 STRING "'192.168.1/24'"
@@ -1170,8 +1377,11 @@ SOURCE_FILE
               EQ "="
             WHITESPACE " "
             CAST_EXPR
-              NAME_REF
-                IDENT "inet"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "inet"
               WHITESPACE " "
               LITERAL
                 STRING "'192.168.1/24'"
@@ -3115,8 +3325,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                JSON_KW "json"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      JSON_KW "json"
             WHITESPACE " "
             CUSTOM_OP
               MINUS "-"
@@ -3139,8 +3352,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                JSON_KW "json"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      JSON_KW "json"
             WHITESPACE " "
             CUSTOM_OP
               MINUS "-"
@@ -3165,8 +3381,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                JSON_KW "json"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      JSON_KW "json"
             WHITESPACE " "
             CUSTOM_OP
               MINUS "-"
@@ -3190,8 +3409,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                JSON_KW "json"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      JSON_KW "json"
             WHITESPACE " "
             CUSTOM_OP
               MINUS "-"
@@ -3217,8 +3439,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                JSON_KW "json"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      JSON_KW "json"
             WHITESPACE " "
             CUSTOM_OP
               POUND "#"
@@ -3243,8 +3468,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                JSON_KW "json"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      JSON_KW "json"
             WHITESPACE " "
             CUSTOM_OP
               POUND "#"
@@ -3270,8 +3498,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               AT "@"
@@ -3283,8 +3514,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -3300,8 +3534,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               L_ANGLE "<"
@@ -3313,8 +3550,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- existence"
@@ -3332,8 +3572,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               QUESTION "?"
@@ -3355,8 +3598,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               QUESTION "?"
@@ -3380,8 +3626,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               QUESTION "?"
@@ -3414,8 +3663,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               QUESTION "?"
@@ -3448,8 +3700,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               PIPE "|"
@@ -3461,8 +3716,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -3478,8 +3736,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               PIPE "|"
@@ -3491,8 +3752,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -3508,8 +3772,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               PIPE "|"
@@ -3521,8 +3788,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -3538,8 +3808,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               PIPE "|"
@@ -3551,8 +3824,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -3568,8 +3844,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               PIPE "|"
@@ -3586,8 +3865,11 @@ SOURCE_FILE
                   COLON_COLON
                     COLON ":"
                     COLON ":"
-                  NAME_REF
-                    IDENT "jsonb"
+                  PATH_TYPE
+                    PATH
+                      PATH_SEGMENT
+                        NAME_REF
+                          IDENT "jsonb"
                 R_PAREN ")"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -3606,8 +3888,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             MINUS "-"
             WHITESPACE " "
@@ -3628,8 +3913,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             MINUS "-"
             WHITESPACE " "
@@ -3650,8 +3938,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             MINUS "-"
             WHITESPACE " "
@@ -3661,11 +3952,12 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              INDEX_EXPR
-                NAME_REF
-                  TEXT_KW "text"
-                L_BRACK "["
-                R_BRACK "]"
+              EXPR_TYPE
+                INDEX_EXPR
+                  NAME_REF
+                    TEXT_KW "text"
+                  L_BRACK "["
+                  R_BRACK "]"
   SEMICOLON ";"
   WHITESPACE "\n"
   SELECT
@@ -3681,8 +3973,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             MINUS "-"
             WHITESPACE " "
@@ -3705,8 +4000,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               POUND "#"
@@ -3731,8 +4029,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               AT "@"
@@ -3757,8 +4058,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "jsonb"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "jsonb"
             WHITESPACE " "
             CUSTOM_OP
               AT "@"
@@ -3815,8 +4119,11 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                NAME_REF
-                  IDENT "jsonb"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "jsonb"
               R_PAREN ")"
             L_BRACK "["
             LITERAL
@@ -3839,8 +4146,11 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                NAME_REF
-                  IDENT "jsonb"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "jsonb"
               R_PAREN ")"
             L_BRACK "["
             LITERAL
@@ -3865,8 +4175,11 @@ SOURCE_FILE
                     COLON_COLON
                       COLON ":"
                       COLON ":"
-                    NAME_REF
-                      IDENT "jsonb"
+                    PATH_TYPE
+                      PATH
+                        PATH_SEGMENT
+                          NAME_REF
+                            IDENT "jsonb"
                   R_PAREN ")"
                 L_BRACK "["
                 LITERAL
@@ -4261,8 +4574,11 @@ SOURCE_FILE
                 COLON_COLON
                   COLON ":"
                   COLON ":"
-                NAME_REF
-                  IDENT "c"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "c"
             WHITESPACE " "
             COLLATE_KW "collate"
             WHITESPACE " "
@@ -4514,8 +4830,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                IDENT "tsrange"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      IDENT "tsrange"
             WHITESPACE " "
             CUSTOM_OP
               AT "@"
@@ -4527,8 +4846,11 @@ SOURCE_FILE
               COLON_COLON
                 COLON ":"
                 COLON ":"
-              NAME_REF
-                TIMESTAMP_KW "timestamp"
+              PATH_TYPE
+                PATH
+                  PATH_SEGMENT
+                    NAME_REF
+                      TIMESTAMP_KW "timestamp"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   COMMENT "-- first contained by second"
@@ -4968,16 +5290,22 @@ SOURCE_FILE
             TUPLE_EXPR
               L_PAREN "("
               CAST_EXPR
-                NAME_REF
-                  IDENT "date"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "date"
                 WHITESPACE " "
                 LITERAL
                   STRING "'2001-02-16'"
               COMMA ","
               WHITESPACE " "
               CAST_EXPR
-                NAME_REF
-                  IDENT "date"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "date"
                 WHITESPACE " "
                 LITERAL
                   STRING "'2001-12-21'"
@@ -4988,16 +5316,22 @@ SOURCE_FILE
             TUPLE_EXPR
               L_PAREN "("
               CAST_EXPR
-                NAME_REF
-                  IDENT "date"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "date"
                 WHITESPACE " "
                 LITERAL
                   STRING "'2001-10-30'"
               COMMA ","
               WHITESPACE " "
               CAST_EXPR
-                NAME_REF
-                  IDENT "date"
+                PATH_TYPE
+                  PATH
+                    PATH_SEGMENT
+                      NAME_REF
+                        IDENT "date"
                 WHITESPACE " "
                 LITERAL
                   STRING "'2002-10-30'"

--- a/crates/squawk_parser/tests/snapshots/tests__values_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__values_ok.snap
@@ -469,8 +469,11 @@ SOURCE_FILE
                   COLON_COLON
                     COLON ":"
                     COLON ":"
-                  NAME_REF
-                    IDENT "inet"
+                  PATH_TYPE
+                    PATH
+                      PATH_SEGMENT
+                        NAME_REF
+                          IDENT "inet"
                 R_PAREN ")"
               COMMA ","
               WHITESPACE " "

--- a/crates/squawk_syntax/src/ast/generated/nodes.rs
+++ b/crates/squawk_syntax/src/ast/generated/nodes.rs
@@ -4786,6 +4786,17 @@ impl Explain {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExprType {
+    pub(crate) syntax: SyntaxNode,
+}
+impl ExprType {
+    #[inline]
+    pub fn expr(&self) -> Option<Expr> {
+        support::child(&self.syntax)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FatArrow {
     pub(crate) syntax: SyntaxNode,
 }
@@ -11218,6 +11229,7 @@ pub enum Type {
     BitType(BitType),
     CharType(CharType),
     DoubleType(DoubleType),
+    ExprType(ExprType),
     IntervalType(IntervalType),
     PathType(PathType),
     PercentType(PercentType),
@@ -15089,6 +15101,24 @@ impl AstNode for Explain {
     #[inline]
     fn can_cast(kind: SyntaxKind) -> bool {
         kind == SyntaxKind::EXPLAIN
+    }
+    #[inline]
+    fn cast(syntax: SyntaxNode) -> Option<Self> {
+        if Self::can_cast(syntax.kind()) {
+            Some(Self { syntax })
+        } else {
+            None
+        }
+    }
+    #[inline]
+    fn syntax(&self) -> &SyntaxNode {
+        &self.syntax
+    }
+}
+impl AstNode for ExprType {
+    #[inline]
+    fn can_cast(kind: SyntaxKind) -> bool {
+        kind == SyntaxKind::EXPR_TYPE
     }
     #[inline]
     fn cast(syntax: SyntaxNode) -> Option<Self> {
@@ -24478,6 +24508,7 @@ impl AstNode for Type {
                 | SyntaxKind::BIT_TYPE
                 | SyntaxKind::CHAR_TYPE
                 | SyntaxKind::DOUBLE_TYPE
+                | SyntaxKind::EXPR_TYPE
                 | SyntaxKind::INTERVAL_TYPE
                 | SyntaxKind::PATH_TYPE
                 | SyntaxKind::PERCENT_TYPE
@@ -24491,6 +24522,7 @@ impl AstNode for Type {
             SyntaxKind::BIT_TYPE => Type::BitType(BitType { syntax }),
             SyntaxKind::CHAR_TYPE => Type::CharType(CharType { syntax }),
             SyntaxKind::DOUBLE_TYPE => Type::DoubleType(DoubleType { syntax }),
+            SyntaxKind::EXPR_TYPE => Type::ExprType(ExprType { syntax }),
             SyntaxKind::INTERVAL_TYPE => Type::IntervalType(IntervalType { syntax }),
             SyntaxKind::PATH_TYPE => Type::PathType(PathType { syntax }),
             SyntaxKind::PERCENT_TYPE => Type::PercentType(PercentType { syntax }),
@@ -24508,6 +24540,7 @@ impl AstNode for Type {
             Type::BitType(it) => &it.syntax,
             Type::CharType(it) => &it.syntax,
             Type::DoubleType(it) => &it.syntax,
+            Type::ExprType(it) => &it.syntax,
             Type::IntervalType(it) => &it.syntax,
             Type::PathType(it) => &it.syntax,
             Type::PercentType(it) => &it.syntax,
@@ -24537,6 +24570,12 @@ impl From<DoubleType> for Type {
     #[inline]
     fn from(node: DoubleType) -> Type {
         Type::DoubleType(node)
+    }
+}
+impl From<ExprType> for Type {
+    #[inline]
+    fn from(node: ExprType) -> Type {
+        Type::ExprType(node)
     }
 }
 impl From<IntervalType> for Type {

--- a/crates/squawk_syntax/src/postgresql.ungram
+++ b/crates/squawk_syntax/src/postgresql.ungram
@@ -288,11 +288,19 @@ Type =
   ArrayType
 | PercentType
 | PathType
+// TODO: I think we can probably simplify the AST nodes for Types & Exprs.
+| ExprType
 | CharType
 | BitType
 | DoubleType
 | TimeType
 | IntervalType
+
+// For when we're parsing expressions and then later we realize they're types.
+// e.g., `select pg_catalog.varchar(10) 'foo'`
+ExprType =
+  // TODO: really just FIELD_EXPR, CALL_EXPR, INDEX_EXPR
+  Expr
 
 Role =
   ('group'? '#ident')

--- a/crates/squawk_syntax/src/snapshots/squawk_syntax__test__alter_table_ok_validation.snap
+++ b/crates/squawk_syntax/src/snapshots/squawk_syntax__test__alter_table_ok_validation.snap
@@ -49,12 +49,13 @@ SOURCE_FILE@0..470
               COLON_COLON@187..189
                 COLON@187..188 ":"
                 COLON@188..189 ":"
-              FIELD_EXPR@189..220
-                NAME_REF@189..201
-                  IDENT@189..201 "custom_types"
-                DOT@201..202 "."
-                NAME_REF@202..220
-                  IDENT@202..220 "widget_schema_type"
+              EXPR_TYPE@189..220
+                FIELD_EXPR@189..220
+                  NAME_REF@189..201
+                    IDENT@189..201 "custom_types"
+                  DOT@201..202 "."
+                  NAME_REF@202..220
+                    IDENT@202..220 "widget_schema_type"
             COMMA@220..221 ","
             WHITESPACE@221..222 " "
             NAME_REF@222..228
@@ -113,12 +114,13 @@ SOURCE_FILE@0..470
               COLON_COLON@403..405
                 COLON@403..404 ":"
                 COLON@404..405 ":"
-              FIELD_EXPR@405..436
-                NAME_REF@405..417
-                  IDENT@405..417 "custom_types"
-                DOT@417..418 "."
-                NAME_REF@418..436
-                  IDENT@418..436 "widget_schema_type"
+              EXPR_TYPE@405..436
+                FIELD_EXPR@405..436
+                  NAME_REF@405..417
+                    IDENT@405..417 "custom_types"
+                  DOT@417..418 "."
+                  NAME_REF@418..436
+                    IDENT@418..436 "widget_schema_type"
             COMMA@436..437 ","
             WHITESPACE@437..438 " "
             NAME_REF@438..454


### PR DESCRIPTION
```sql
select
  '{123}'::pg_catalog.varchar(10)[],
  '{123}'::pg_catalog.varchar(10),
  '{123}'::pg_catalog.varchar,
  '{123}'::varchar,
  cast('{123}' as pg_catalog.varchar(10)[]),
  pg_catalog.varchar(10) '{123}',
  interval '1' month;
```

Make sure we can call the `.ty()` and `.expr()` method on `ast::CastExpr` and have things just work.