### PR TITLE
parser: fix reindex parsing

### DIFF
--- a/crates/squawk_parser/src/grammar.rs
+++ b/crates/squawk_parser/src/grammar.rs
@@ -11301,7 +11301,7 @@ fn reindex(p: &mut Parser<'_>) -> CompletedMarker {
         }
     };
     p.eat(CONCURRENTLY_KW);
-    if opt_path_name(p).is_none() && name_required {
+    if opt_path_name_ref(p).is_none() && name_required {
         p.error("expected name");
     }
     m.complete(p, REINDEX)

--- a/crates/squawk_parser/tests/snapshots/tests__reindex_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__reindex_err.snap
@@ -23,7 +23,7 @@ SOURCE_FILE
     WHITESPACE " "
     PATH
       PATH_SEGMENT
-        NAME
+        NAME_REF
           IDENT "i"
   SEMICOLON ";"
   WHITESPACE "\n"

--- a/crates/squawk_parser/tests/snapshots/tests__reindex_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__reindex_ok.snap
@@ -12,7 +12,7 @@ SOURCE_FILE
     WHITESPACE " "
     PATH
       PATH_SEGMENT
-        NAME
+        NAME_REF
           IDENT "my_index"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -23,7 +23,7 @@ SOURCE_FILE
     WHITESPACE " "
     PATH
       PATH_SEGMENT
-        NAME
+        NAME_REF
           IDENT "my_table"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -36,7 +36,7 @@ SOURCE_FILE
     WHITESPACE " "
     PATH
       PATH_SEGMENT
-        NAME
+        NAME_REF
           IDENT "my_broken_table"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -70,7 +70,7 @@ SOURCE_FILE
     WHITESPACE " "
     PATH
       PATH_SEGMENT
-        NAME
+        NAME_REF
           IDENT "foo"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -81,7 +81,7 @@ SOURCE_FILE
     WHITESPACE " "
     PATH
       PATH_SEGMENT
-        NAME
+        NAME_REF
           IDENT "foo"
   SEMICOLON ";"
   WHITESPACE "\n\n"
@@ -92,7 +92,7 @@ SOURCE_FILE
     WHITESPACE " "
     PATH
       PATH_SEGMENT
-        NAME
+        NAME_REF
           IDENT "foo"
   SEMICOLON ";"
   WHITESPACE "\n"
@@ -103,7 +103,7 @@ SOURCE_FILE
     WHITESPACE " "
     PATH
       PATH_SEGMENT
-        NAME
+        NAME_REF
           IDENT "foo"
   SEMICOLON ";"
   WHITESPACE "\n"
@@ -114,7 +114,7 @@ SOURCE_FILE
     WHITESPACE " "
     PATH
       PATH_SEGMENT
-        NAME
+        NAME_REF
           IDENT "foo"
   SEMICOLON ";"
   WHITESPACE "\n\n"


### PR DESCRIPTION
we were using a name instead of a name_ref for the table name