### PR TITLE
fix: Removed deprecated cargo_bin() function in snapbox

### DIFF
--- a/crates/squawk/tests/example_output.rs
+++ b/crates/squawk/tests/example_output.rs
@@ -3,7 +3,7 @@ use snapbox::{cmd::Command, file};
 #[test]
 fn example_sql_svg() {
     let expected = file!["../src/snapshots/example.svg": TermSvg];
-    let bin_path = snapbox::cmd::cargo_bin("squawk");
+    let bin_path = snapbox::cmd::cargo_bin!("squawk");
     Command::new(bin_path)
         .env("CLICOLOR_FORCE", "1")
         .env("SQUAWK_DISABLE_GITHUB_ANNOTATIONS", "1")


### PR DESCRIPTION
See the deprecation notice in the [snapbox docs](https://docs.rs/snapbox/latest/snapbox/cmd/fn.cargo_bin.html).

fixes #745