### PR TITLE
parser: use annotate-snippets in parser errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,6 +1915,7 @@ dependencies = [
 name = "squawk-parser"
 version = "2.33.2"
 dependencies = [
+ "annotate-snippets",
  "camino",
  "dir-test",
  "drop_bomb",

--- a/crates/squawk_parser/Cargo.toml
+++ b/crates/squawk_parser/Cargo.toml
@@ -24,6 +24,7 @@ dir-test.workspace = true
 camino.workspace = true
 pg_query.workspace = true
 xshell.workspace = true
+annotate-snippets.workspace = true
 
 [lints]
 workspace = true

--- a/crates/squawk_parser/tests/snapshots/tests__alter_foreign_data_wrapper_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__alter_foreign_data_wrapper_err.snap
@@ -19,4 +19,7 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@46: Missing alter foreign data wrapper option or action.
+error[syntax-error]: Missing alter foreign data wrapper option or action.
+  ╭▸ 
+2 │ alter foreign data wrapper w;
+  ╰╴                            ━

--- a/crates/squawk_parser/tests/snapshots/tests__alter_sequence_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__alter_sequence_err.snap
@@ -17,4 +17,7 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@34: expected ALTER SEQUENCE option
+error[syntax-error]: expected ALTER SEQUENCE option
+  ╭▸ 
+2 │ alter sequence s;
+  ╰╴                ━

--- a/crates/squawk_parser/tests/snapshots/tests__alter_server_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__alter_server_err.snap
@@ -15,4 +15,7 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@32: expected ALTER SERVER option
+error[syntax-error]: expected ALTER SERVER option
+  ╭▸ 
+2 │ alter server s;
+  ╰╴              ━

--- a/crates/squawk_parser/tests/snapshots/tests__alter_table_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__alter_table_err.snap
@@ -210,10 +210,31 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@23: expected command, found ADD_KW
-ERROR@27: expected command, found COLUMN_KW
-ERROR@34: expected command, found IDENT
-ERROR@38: expected command, found BOOLEAN_KW
-ERROR@175: missing comma
-ERROR@505: expected COMMA
-ERROR@570: unexpected comma
+error[syntax-error]: expected command, found ADD_KW
+  ╭▸ 
+2 │ add column foo boolean;
+  ╰╴━
+error[syntax-error]: expected command, found COLUMN_KW
+  ╭▸ 
+2 │ add column foo boolean;
+  ╰╴    ━
+error[syntax-error]: expected command, found IDENT
+  ╭▸ 
+2 │ add column foo boolean;
+  ╰╴           ━
+error[syntax-error]: expected command, found BOOLEAN_KW
+  ╭▸ 
+2 │ add column foo boolean;
+  ╰╴               ━
+error[syntax-error]: missing comma
+  ╭▸ 
+8 │ validate constraint foo validate constraint b ;
+  ╰╴                       ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+16 │   alter c set (a b = 1);
+   ╰╴                ━
+error[syntax-error]: unexpected comma
+   ╭▸ 
+20 │   alter c set (a, , b = 1);
+   ╰╴                  ━

--- a/crates/squawk_parser/tests/snapshots/tests__copy_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__copy_err.snap
@@ -43,5 +43,11 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@36: expected COMMA
-ERROR@79: expected COMMA
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ copy x (i y) from '/tmp/input.file' (on_error ignore  log_verbosity verbose);
+  ╰╴         ━
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ copy x (i y) from '/tmp/input.file' (on_error ignore  log_verbosity verbose);
+  ╰╴                                                    ━

--- a/crates/squawk_parser/tests/snapshots/tests__create_function_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__create_function_err.snap
@@ -129,7 +129,23 @@ SOURCE_FILE
     FUNCTION_KW "function"
   WHITESPACE "\n\n"
 ---
-ERROR@58: expected COMMA
-ERROR@121: expected COMMA
-ERROR@249: expected path name
-ERROR@249: expected param list
+error[syntax-error]: expected COMMA
+  ╭▸ 
+3 │ returns table (a text  b int)
+  ╰╴                     ━
+error[syntax-error]: expected COMMA
+  ╭▸ 
+6 │ create function foo(arg float = 1 int4 = 4)
+  ╰╴                                 ━
+error[syntax-error]: expected path name
+   ╭▸ 
+13 │   create function
+   │ ┏━━━━━━━━━━━━━━━━┛
+14 │ ┃
+   ╰╴┗━┛
+error[syntax-error]: expected param list
+   ╭▸ 
+13 │   create function
+   │ ┏━━━━━━━━━━━━━━━━┛
+14 │ ┃
+   ╰╴┗━┛

--- a/crates/squawk_parser/tests/snapshots/tests__create_index_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__create_index_err.snap
@@ -44,4 +44,7 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@51: expected COMMA
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ create index i on t (a nulls first b nulls first);
+  ╰╴                                  ━

--- a/crates/squawk_parser/tests/snapshots/tests__create_table_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__create_table_err.snap
@@ -673,16 +673,57 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@39: expected path name
-ERROR@143: unexpected trailing comma
-ERROR@197: unexpected comma
-ERROR@198: unexpected comma
-ERROR@199: unexpected comma
-ERROR@200: unexpected comma
-ERROR@201: unexpected comma
-ERROR@1011: expected COMMA
-ERROR@1032: expected COMMA
-ERROR@1116: expected COMMA
-ERROR@1119: expected COMMA
-ERROR@1226: expected COMMA
-ERROR@1268: expected SEMICOLON
+error[syntax-error]: expected path name
+  ╭▸ 
+2 │ create table (
+  ╰╴            ━
+error[syntax-error]: unexpected trailing comma
+   ╭▸ 
+10 │ create table t (a text,);
+   ╰╴                      ━
+error[syntax-error]: unexpected comma
+   ╭▸ 
+13 │ create table t (,,,,,);
+   ╰╴                ━
+error[syntax-error]: unexpected comma
+   ╭▸ 
+13 │ create table t (,,,,,);
+   ╰╴                 ━
+error[syntax-error]: unexpected comma
+   ╭▸ 
+13 │ create table t (,,,,,);
+   ╰╴                  ━
+error[syntax-error]: unexpected comma
+   ╭▸ 
+13 │ create table t (,,,,,);
+   ╰╴                   ━
+error[syntax-error]: unexpected comma
+   ╭▸ 
+13 │ create table t (,,,,,);
+   ╰╴                    ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+51 │     for values from ('2024-01-01'  1) to ('2024-04-01'  5);
+   ╰╴                                 ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+51 │     for values from ('2024-01-01'  1) to ('2024-04-01'  5);
+   ╰╴                                                      ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+55 │     for values in (1  2  3);
+   ╰╴                    ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+55 │     for values in (1  2  3);
+   ╰╴                       ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+61 │   exclude using btree ( a with buzz.> b with <) 
+   ╰╴                                     ━
+error[syntax-error]: expected SEMICOLON
+   ╭▸ 
+66 │   )
+   │ ┏━━┛
+67 │ ┃ -- ^ missing semi
+   ╰╴┗━┛

--- a/crates/squawk_parser/tests/snapshots/tests__drop_database_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__drop_database_err.snap
@@ -25,4 +25,7 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@45: expected COMMA
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ drop database d with ( force  force );
+  ╰╴                            ━

--- a/crates/squawk_parser/tests/snapshots/tests__drop_table_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__drop_table_err.snap
@@ -54,5 +54,11 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@36: expected COMMA
-ERROR@86: unexpected comma, expected a name
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ drop table foo, bar buzz cascade;
+  ╰╴                   ━
+error[syntax-error]: unexpected comma, expected a name
+  ╭▸ 
+5 │ drop table foo,   , buzz cascade;
+  ╰╴                  ━

--- a/crates/squawk_parser/tests/snapshots/tests__insert_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__insert_err.snap
@@ -176,8 +176,23 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@51: expected COMMA
-ERROR@168: missing column
-ERROR@170: unexpected trailing comma
-ERROR@301: expected COMMA
-ERROR@304: unexpected trailing comma
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ insert into t (a, b c)
+  ╰╴                   ━
+error[syntax-error]: missing column
+  ╭▸ 
+7 │ insert into t (a,,c,)
+  ╰╴                 ━
+error[syntax-error]: unexpected trailing comma
+  ╭▸ 
+7 │ insert into t (a,,c,)
+  ╰╴                   ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+13 │   values (4, 5  6,)
+   ╰╴              ━
+error[syntax-error]: unexpected trailing comma
+   ╭▸ 
+13 │   values (4, 5  6,)
+   ╰╴                 ━

--- a/crates/squawk_parser/tests/snapshots/tests__prepare_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__prepare_err.snap
@@ -78,5 +78,11 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@38: expected COMMA
-ERROR@44: expected COMMA
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ PREPARE fooplan (int  text  bool, numeric) AS
+  ╰╴                    ━
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ PREPARE fooplan (int  text  bool, numeric) AS
+  ╰╴                          ━

--- a/crates/squawk_parser/tests/snapshots/tests__reindex_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__reindex_err.snap
@@ -28,5 +28,11 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@39: expected COMMA
-ERROR@47: expected COMMA
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ reindex (concurrently verbose tablespace t) index i;
+  ╰╴                     ━
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ reindex (concurrently verbose tablespace t) index i;
+  ╰╴                             ━

--- a/crates/squawk_parser/tests/snapshots/tests__select_cte_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_cte_err.snap
@@ -333,9 +333,27 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@24: unexpected comma
-ERROR@140: unexpected comma, expected a column name
-ERROR@270: expected COMMA
-ERROR@357: missing comma
-ERROR@492: missing comma
-ERROR@645: unexpected comma
+error[syntax-error]: unexpected comma
+  ╭▸ 
+3 │ ), -- <--- extra comma!
+  ╰╴ ━
+error[syntax-error]: unexpected comma, expected a column name
+  ╭▸ 
+8 │ search depth first by a, , c set ordercol
+  ╰╴                         ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+13 │ search depth first by a, b c set ordercol
+   ╰╴                          ━
+error[syntax-error]: missing comma
+   ╭▸ 
+19 │    ) -- <-- missing a comma
+   ╰╴    ━
+error[syntax-error]: missing comma
+   ╭▸ 
+29 │    ) -- <-- missing a comma
+   ╰╴    ━
+error[syntax-error]: unexpected comma
+   ╭▸ 
+38 │    ), -- <-- extra comma
+   ╰╴    ━

--- a/crates/squawk_parser/tests/snapshots/tests__select_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_err.snap
@@ -699,32 +699,119 @@ SOURCE_FILE
           COMMA ","
   WHITESPACE "\n"
 ---
-ERROR@124: unexpected trailing comma
-ERROR@153: unexpected trailing comma
-ERROR@213: unexpected trailing comma
-ERROR@248: missing comma
-ERROR@378: expected COMMA
-ERROR@494: expected COMMA
-ERROR@496: expected COMMA
-ERROR@533: expected COMMA
-ERROR@535: expected COMMA
-ERROR@583: expected COMMA
-ERROR@586: expected COMMA
-ERROR@663: unexpected trailing comma
-ERROR@695: expected expression
-ERROR@696: expected expression
-ERROR@697: expected expression
-ERROR@698: expected expression
-ERROR@821: missing comma
-ERROR@860: expected COMMA
-ERROR@898: unexpected comma
-ERROR@939: unexpected trailing comma
-ERROR@1009: expected COMMA
-ERROR@1047: unexpected comma
-ERROR@1079: unexpected trailing comma
-ERROR@1203: expected SEMICOLON
-ERROR@1236: unexpected trailing comma
-ERROR@1296: expected an expression, found END_KW
-ERROR@1345: expected an expression, found THEN_KW
-ERROR@1415: expected an expression, found END_KW
-ERROR@1455: unexpected trailing comma
+error[syntax-error]: unexpected trailing comma
+  ╭▸ 
+4 │   array['a', 'b', 'c',] as y,
+  ╰╴                     ━
+error[syntax-error]: unexpected trailing comma
+  ╭▸ 
+5 │   'hello world' as z,
+  ╰╴                    ━
+error[syntax-error]: unexpected trailing comma
+  ╭▸ 
+9 │ select * from t as u(a,);
+  ╰╴                      ━
+error[syntax-error]: missing comma
+   ╭▸ 
+12 │ select a, b c  d, e from t;
+   ╰╴             ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+17 │ SELECT DISTINCT ON (a b) a, b, c
+   ╰╴                     ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+22 │ select * from t group by rollup (1 2 3);
+   ╰╴                                  ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+22 │ select * from t group by rollup (1 2 3);
+   ╰╴                                    ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+23 │ select * from t group by cube (1 2 3);
+   ╰╴                                ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+23 │ select * from t group by cube (1 2 3);
+   ╰╴                                  ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+25 │   group by grouping sets((1 2) grouping sets((), grouping sets(())));
+   ╰╴                           ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+25 │   group by grouping sets((1 2) grouping sets((), grouping sets(())));
+   ╰╴                              ━
+error[syntax-error]: unexpected trailing comma
+   ╭▸ 
+28 │ select f(1,);
+   ╰╴          ━
+error[syntax-error]: expected expression
+   ╭▸ 
+31 │ select f(a,,,,,);
+   ╰╴           ━
+error[syntax-error]: expected expression
+   ╭▸ 
+31 │ select f(a,,,,,);
+   ╰╴            ━
+error[syntax-error]: expected expression
+   ╭▸ 
+31 │ select f(a,,,,,);
+   ╰╴             ━
+error[syntax-error]: expected expression
+   ╭▸ 
+31 │ select f(a,,,,,);
+   ╰╴              ━
+error[syntax-error]: missing comma
+   ╭▸ 
+37 │ select numeric 1234;
+   ╰╴              ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+40 │ select array[1 2,3];
+   ╰╴              ━
+error[syntax-error]: unexpected comma
+   ╭▸ 
+42 │ select array[1, ,3];
+   ╰╴                ━
+error[syntax-error]: unexpected trailing comma
+   ╭▸ 
+44 │ select array[1,2,3,];
+   ╰╴                  ━
+error[syntax-error]: expected COMMA
+   ╭▸ 
+47 │ select cast(x as varchar(100 200));
+   ╰╴                            ━
+error[syntax-error]: unexpected comma
+   ╭▸ 
+48 │ select cast(x as varchar(100, , 200));
+   ╰╴                              ━
+error[syntax-error]: unexpected trailing comma
+   ╭▸ 
+49 │ select cast(x as t(a, b,));
+   ╰╴                       ━
+error[syntax-error]: expected SEMICOLON
+   ╭▸ 
+53 │ select select;
+   ╰╴      ━
+error[syntax-error]: unexpected trailing comma
+   ╭▸ 
+56 │ select a, from t;
+   ╰╴        ━
+error[syntax-error]: expected an expression, found END_KW
+   ╭▸ 
+59 │ select case when 1 then end;
+   ╰╴                       ━
+error[syntax-error]: expected an expression, found THEN_KW
+   ╭▸ 
+62 │ select case when then x end;
+   ╰╴                ━
+error[syntax-error]: expected an expression, found END_KW
+   ╭▸ 
+65 │ select case when 1 then 2 else end;
+   ╰╴                              ━
+error[syntax-error]: unexpected trailing comma
+   ╭▸ 
+68 │ select 1,
+   ╰╴        ━

--- a/crates/squawk_parser/tests/snapshots/tests__update_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__update_err.snap
@@ -84,5 +84,11 @@ SOURCE_FILE
   COMMENT "--                ^ missing comma"
   WHITESPACE "\n"
 ---
-ERROR@15: expected COMMA
-ERROR@79: expected COMMA
+error[syntax-error]: expected COMMA
+  ╭▸ 
+1 │ update t set (j k) = (1, 2);
+  ╰╴               ━
+error[syntax-error]: expected COMMA
+  ╭▸ 
+4 │ update t set a = 1 b = 2;
+  ╰╴                  ━

--- a/crates/squawk_parser/tests/snapshots/tests__vacuum_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__vacuum_err.snap
@@ -28,5 +28,11 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@35: expected COMMA
-ERROR@49: expected COMMA
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ vacuum (full analyze false skip_locked true);
+  ╰╴            ━
+error[syntax-error]: expected COMMA
+  ╭▸ 
+2 │ vacuum (full analyze false skip_locked true);
+  ╰╴                          ━

--- a/crates/squawk_parser/tests/snapshots/tests__values_err.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__values_err.snap
@@ -48,6 +48,15 @@ SOURCE_FILE
   SEMICOLON ";"
   WHITESPACE "\n"
 ---
-ERROR@66: unexpected trailing comma
-ERROR@68: expected COMMA
-ERROR@120: expected L_PAREN
+error[syntax-error]: unexpected trailing comma
+  ╭▸ 
+3 │ values (1,) (1);
+  ╰╴         ━
+error[syntax-error]: expected COMMA
+  ╭▸ 
+3 │ values (1,) (1);
+  ╰╴           ━
+error[syntax-error]: expected L_PAREN
+  ╭▸ 
+6 │ values (1),, (2);
+  ╰╴           ━


### PR DESCRIPTION
instead of:

```
ERROR@124: unexpected trailing comma
```

we now show

```
error[syntax-error]: unexpected trailing comma
  ╭▸
4 │   array['a', 'b', 'c',] as y,
  ╰╴                     ━
```

which should make debugging test errors a little easier