### PR TITLE
docs(readme): bump version of squawk in pre-commit demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ to your project's `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sbdchd/squawk
-    rev: v0.10.0
+    rev: v2.38.0
     hooks:
       - id: squawk
         files: path/to/postgres/migrations/written/in/sql


### PR DESCRIPTION
### What was wrong?
When I'm following the pre-commit demo from the readme I get the error during `pre-commit` install or `git commit`:

```sh
[INFO] Initializing environment for https://github.com/sbdchd/squawk
An error has occurred: InvalidManifestError:
=====> /.../.cache/pre-commit/.../.pre-commit-hooks.yaml is not a file
```

I checked and `.pre-commit-hooks.yaml` does not exist in tag `v0.10.0`

### How was it fixed?
Bump version in the readme demo to the latest release: `v2.38.0`