### PR TITLE
ide: semantic syntax highlighting

### DIFF
--- a/crates/squawk_ide/src/lib.rs
+++ b/crates/squawk_ide/src/lib.rs
@@ -18,6 +18,7 @@ mod offsets;
 mod quote;
 mod resolve;
 mod scope;
+pub mod semantic_tokens;
 mod symbols;
 #[cfg(test)]
 pub mod test_utils;

--- a/crates/squawk_ide/src/semantic_tokens.rs
+++ b/crates/squawk_ide/src/semantic_tokens.rs
@@ -1,0 +1,174 @@
+use rowan::{NodeOrToken, TextRange};
+use salsa::Database as Db;
+use squawk_syntax::{
+    SyntaxKind,
+    ast::{self, AstNode},
+};
+
+use crate::db::{File, parse};
+
+/// A semantic token with its position and classification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticToken {
+    pub range: TextRange,
+    pub token_type: SemanticTokenType,
+    pub modifiers: Option<SemanticTokenModifier>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum SemanticTokenModifier {
+    Definition = 0,
+    Readonly,
+    Documentation,
+}
+
+/// Semantic token types supported by the language server.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SemanticTokenType {
+    Keyword,
+    String,
+    Bool,
+    Number,
+    Function,
+    Operator,
+    Punctuation,
+    Name,
+    NameRef,
+    Comment,
+    Type,
+    Parameter,
+    PositionalParam,
+}
+
+#[salsa::tracked]
+pub fn semantic_tokens(
+    db: &dyn Db,
+    file: File,
+    range_to_highlight: Option<TextRange>,
+) -> Vec<SemanticToken> {
+    let parse = parse(db, file);
+    let tree = parse.tree();
+    let root = tree.syntax();
+
+    // Determine the root based on the given range.
+    let (root, range_to_highlight) = {
+        let source_file = root;
+        match range_to_highlight {
+            Some(range) => {
+                let node = match source_file.covering_element(range) {
+                    NodeOrToken::Node(it) => it,
+                    NodeOrToken::Token(it) => it.parent().unwrap_or_else(|| source_file.clone()),
+                };
+                (node, range)
+            }
+            None => (source_file.clone(), source_file.text_range()),
+        }
+    };
+
+    let mut out = vec![];
+
+    // Taken from: https://github.com/rust-lang/rust-analyzer/blob/2efc80078029894eec0699f62ec8d5c1a56af763/crates/ide/src/syntax_highlighting.rs#L267C21-L267C21
+    let preorder = root.preorder_with_tokens();
+    for event in preorder {
+        use rowan::WalkEvent::{Enter, Leave};
+
+        let range = match &event {
+            Enter(it) | Leave(it) => it.text_range(),
+        };
+
+        // Element outside of the viewport, no need to highlight
+        if range_to_highlight.intersect(range).is_none() {
+            continue;
+        }
+
+        match event {
+            Enter(NodeOrToken::Node(node)) => {
+                if let Some(target) = ast::Target::cast(node) {
+                    if let Some(as_name) = target.as_name() {
+                        if let Some(name) = as_name.name() {
+                            let range = name.syntax().text_range();
+                            out.push(SemanticToken {
+                                range,
+                                token_type: SemanticTokenType::Name,
+                                modifiers: None,
+                            });
+                        }
+                    }
+                };
+            }
+            Enter(NodeOrToken::Token(token)) => {
+                if token.kind() == SyntaxKind::WHITESPACE {
+                    continue;
+                }
+                if token.kind() == SyntaxKind::POSITIONAL_PARAM {
+                    out.push(SemanticToken {
+                        range: token.text_range(),
+                        token_type: SemanticTokenType::PositionalParam,
+                        modifiers: None,
+                    })
+                }
+            }
+            Leave(_) => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod test {
+    use crate::db::{Database, File};
+    use insta::assert_snapshot;
+    use std::fmt::Write;
+
+    fn semantic_tokens(sql: &str) -> String {
+        let db = Database::default();
+        let file = File::new(&db, sql.to_string().into());
+        let tokens = super::semantic_tokens(&db, file, None);
+
+        let mut result = String::new();
+        for token in tokens {
+            let start: usize = token.range.start().into();
+            let end: usize = token.range.end().into();
+            let token_text = &sql[start..end];
+            // TODO:
+            let modifiers_text = "";
+            writeln!(
+                result,
+                "{:?} @ {}..{}: {:?}{}",
+                token_text, start, end, token.token_type, modifiers_text
+            )
+            .unwrap();
+        }
+        result
+    }
+
+    #[test]
+    fn create_function() {
+        assert_snapshot!(semantic_tokens("
+create function add(a int, b int) returns int
+  as 'select $1 + $2'
+  language sql;
+"), @"");
+    }
+
+    #[test]
+    fn select_keywords() {
+        assert_snapshot!(semantic_tokens("
+select 1 and, 2 select;
+"), @r#"
+        "and" @ 10..13: Name
+        "select" @ 17..23: Name
+        "#)
+    }
+
+    #[test]
+    fn positional_param() {
+        assert_snapshot!(semantic_tokens("
+select $1, $2;
+"), @r#"
+        "$1" @ 8..10: PositionalParam
+        "$2" @ 12..14: PositionalParam
+        "#)
+    }
+}

--- a/crates/squawk_ide/src/semantic_tokens.rs
+++ b/crates/squawk_ide/src/semantic_tokens.rs
@@ -131,7 +131,7 @@ mod test {
             let start: usize = token.range.start().into();
             let end: usize = token.range.end().into();
             let token_text = &sql[start..end];
-            // TODO:
+            // TODO: once we get modfifiers, we'll need to update this
             let modifiers_text = "";
             writeln!(
                 result,

--- a/crates/squawk_ide/src/semantic_tokens.rs
+++ b/crates/squawk_ide/src/semantic_tokens.rs
@@ -84,17 +84,16 @@ pub fn semantic_tokens(
 
         match event {
             Enter(NodeOrToken::Node(node)) => {
-                if let Some(target) = ast::Target::cast(node) {
-                    if let Some(as_name) = target.as_name() {
-                        if let Some(name) = as_name.name() {
-                            let range = name.syntax().text_range();
-                            out.push(SemanticToken {
-                                range,
-                                token_type: SemanticTokenType::Name,
-                                modifiers: None,
-                            });
-                        }
-                    }
+                if let Some(target) = ast::Target::cast(node)
+                    && let Some(as_name) = target.as_name()
+                    && let Some(name) = as_name.name()
+                {
+                    let range = name.syntax().text_range();
+                    out.push(SemanticToken {
+                        range,
+                        token_type: SemanticTokenType::Name,
+                        modifiers: None,
+                    });
                 };
             }
             Enter(NodeOrToken::Token(token)) => {

--- a/crates/squawk_parser/src/grammar.rs
+++ b/crates/squawk_parser/src/grammar.rs
@@ -2511,7 +2511,9 @@ fn expr_bp(p: &mut Parser<'_>, bp: u8, r: &Restrictions) -> Option<CompletedMark
         // could be start of `is distinct from`
         && !(p.at(IS_KW) && p.nth_at(1, DISTINCT_KW))
     {
+        let m = p.start();
         col_label(p);
+        m.complete(p, AS_NAME);
         return Some(lhs);
     }
     if r.order_by_allowed && p.at(ORDER_KW) {

--- a/crates/squawk_parser/tests/snapshots/tests__select_ok.snap
+++ b/crates/squawk_parser/tests/snapshots/tests__select_ok.snap
@@ -5780,8 +5780,9 @@ SOURCE_FILE
           LITERAL
             INT_NUMBER "1"
           WHITESPACE " "
-          NAME
-            IS_KW "is"
+          AS_NAME
+            NAME
+              IS_KW "is"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -5793,8 +5794,9 @@ SOURCE_FILE
           LITERAL
             INT_NUMBER "1"
           WHITESPACE " "
-          NAME
-            AND_KW "and"
+          AS_NAME
+            NAME
+              AND_KW "and"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -5806,8 +5808,9 @@ SOURCE_FILE
           LITERAL
             INT_NUMBER "1"
           WHITESPACE " "
-          NAME
-            OR_KW "or"
+          AS_NAME
+            NAME
+              OR_KW "or"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT
@@ -5819,8 +5822,9 @@ SOURCE_FILE
           LITERAL
             INT_NUMBER "1"
           WHITESPACE " "
-          NAME
-            COLLATE_KW "collate"
+          AS_NAME
+            NAME
+              COLLATE_KW "collate"
   SEMICOLON ";"
   WHITESPACE "\n\n"
   SELECT

--- a/crates/squawk_server/src/global_state.rs
+++ b/crates/squawk_server/src/global_state.rs
@@ -16,7 +16,7 @@ use squawk_thread::TaskPool;
 use lsp_types::request::{
     CodeActionRequest, Completion, DocumentDiagnosticRequest, DocumentSymbolRequest,
     FoldingRangeRequest, GotoDefinition, HoverRequest, InlayHintRequest, References,
-    SelectionRangeRequest, Shutdown,
+    SelectionRangeRequest, SemanticTokensFullRequest, SemanticTokensRangeRequest, Shutdown,
 };
 
 use crate::dispatch::{NotificationDispatcher, RequestDispatcher};
@@ -24,8 +24,8 @@ use crate::handlers::{
     SyntaxTreeRequest, TokensRequest, handle_cancel, handle_code_action, handle_completion,
     handle_did_change, handle_did_close, handle_did_open, handle_document_diagnostic,
     handle_document_symbol, handle_folding_range, handle_goto_definition, handle_hover,
-    handle_inlay_hints, handle_references, handle_selection_range, handle_shutdown,
-    handle_syntax_tree, handle_tokens,
+    handle_inlay_hints, handle_references, handle_selection_range, handle_semantic_tokens_full,
+    handle_semantic_tokens_range, handle_shutdown, handle_syntax_tree, handle_tokens,
 };
 
 type ReqQueue = lsp_server::ReqQueue<(String, Instant), ()>;
@@ -230,6 +230,8 @@ impl GlobalState {
             .on::<NO_RETRY, SyntaxTreeRequest>(handle_syntax_tree)
             .on::<NO_RETRY, TokensRequest>(handle_tokens)
             .on::<NO_RETRY, References>(handle_references)
+            .on::<NO_RETRY, SemanticTokensFullRequest>(handle_semantic_tokens_full)
+            .on::<NO_RETRY, SemanticTokensRangeRequest>(handle_semantic_tokens_range)
             .finish();
     }
 }

--- a/crates/squawk_server/src/handlers.rs
+++ b/crates/squawk_server/src/handlers.rs
@@ -9,6 +9,7 @@ mod inlay_hints;
 mod notifications;
 mod references;
 mod selection_range;
+mod semantic_tokens;
 mod shutdown;
 mod syntax_tree;
 mod tokens;
@@ -26,6 +27,7 @@ pub(crate) use notifications::{
 };
 pub(crate) use references::handle_references;
 pub(crate) use selection_range::handle_selection_range;
+pub(crate) use semantic_tokens::{handle_semantic_tokens_full, handle_semantic_tokens_range};
 pub(crate) use shutdown::handle_shutdown;
 pub(crate) use syntax_tree::{SyntaxTreeRequest, handle_syntax_tree};
 pub(crate) use tokens::{TokensRequest, handle_tokens};

--- a/crates/squawk_server/src/handlers/semantic_tokens.rs
+++ b/crates/squawk_server/src/handlers/semantic_tokens.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+use lsp_types::{
+    SemanticTokens, SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
+    SemanticTokensResult,
+};
+
+use squawk_ide::db::line_index;
+use squawk_ide::semantic_tokens::semantic_tokens;
+
+use crate::global_state::Snapshot;
+use crate::lsp_utils;
+
+pub(crate) fn handle_semantic_tokens_full(
+    snapshot: &Snapshot,
+    params: SemanticTokensParams,
+) -> Result<Option<SemanticTokensResult>> {
+    let uri = params.text_document.uri;
+    let db = snapshot.db();
+    let file = snapshot.file(&uri).unwrap();
+    let line_index = line_index(db, file);
+    let text = file.content(db);
+    let tokens = semantic_tokens(db, file, None);
+    Ok(Some(SemanticTokensResult::Tokens(SemanticTokens {
+        result_id: None,
+        data: lsp_utils::to_semantic_tokens(text, line_index, tokens),
+    })))
+}
+
+pub(crate) fn handle_semantic_tokens_range(
+    snapshot: &Snapshot,
+    params: SemanticTokensRangeParams,
+) -> Result<Option<SemanticTokensRangeResult>> {
+    let uri = params.text_document.uri;
+    let db = snapshot.db();
+    let file = snapshot.file(&uri).unwrap();
+    let line_index = line_index(db, file);
+    let range_to_highlight = lsp_utils::text_range(&line_index, params.range);
+    let tokens = semantic_tokens(db, file, range_to_highlight);
+    let text = file.content(db);
+    Ok(Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
+        result_id: None,
+        data: lsp_utils::to_semantic_tokens(text, line_index, tokens),
+    })))
+}

--- a/crates/squawk_server/src/lib.rs
+++ b/crates/squawk_server/src/lib.rs
@@ -6,6 +6,7 @@ mod ignore;
 mod lint;
 mod lsp_utils;
 mod panic;
+mod semantic_tokens;
 mod server;
 
 pub use server::run;

--- a/crates/squawk_server/src/lsp_utils.rs
+++ b/crates/squawk_server/src/lsp_utils.rs
@@ -6,16 +6,18 @@ use ::line_index::{LineIndex, TextRange, TextSize};
 use log::warn;
 use lsp_types::{
     CodeAction, CodeActionKind, FoldingRange, FoldingRangeKind as LspFoldingRangeKind, Location,
-    Url, WorkspaceEdit,
+    SemanticToken, Url, WorkspaceEdit,
 };
 use squawk_ide::builtins::{builtins_line_index, builtins_url};
 use squawk_ide::code_actions::ActionKind;
 use squawk_ide::db::line_index;
 use squawk_ide::folding_ranges::{Fold, FoldKind};
+use squawk_ide::semantic_tokens::{SemanticTokenModifier, SemanticTokenType};
 
 use crate::global_state::Snapshot;
+use crate::semantic_tokens;
 
-fn text_range(index: &LineIndex, range: lsp_types::Range) -> Option<TextRange> {
+pub(crate) fn text_range(index: &LineIndex, range: lsp_types::Range) -> Option<TextRange> {
     let start = offset(index, range.start)?;
     let end = offset(index, range.end)?;
     if end >= start {
@@ -227,6 +229,96 @@ pub(crate) fn to_location(
     };
     let range = range(line_index, loc.range);
     Some(Location { uri, range })
+}
+
+pub(crate) fn to_semantic_tokens(
+    text: &str,
+    line_index: LineIndex,
+    semantic_tokens: Vec<squawk_ide::semantic_tokens::SemanticToken>,
+) -> Vec<lsp_types::SemanticToken> {
+    let mut encoder = Encoder {
+        tokens: Vec::with_capacity(semantic_tokens.len()),
+        prev_line: 0,
+        prev_start: 0,
+    };
+
+    for token in &*semantic_tokens {
+        // Taken from rust-analyzer, this solves the case where we have a multi
+        // line semantic token which isn't supported by the LSP spec.
+        // see: https://github.com/rust-lang/rust-analyzer/blob/2efc80078029894eec0699f62ec8d5c1a56af763/crates/rust-analyzer/src/lsp/to_proto.rs#L781C28-L781C28
+        for mut text_range in line_index.lines(token.range) {
+            if text[text_range].ends_with('\n') {
+                text_range =
+                    TextRange::new(text_range.start(), text_range.end() - TextSize::of('\n'));
+            }
+            let lsp_range = range(&line_index, text_range);
+            let len = lsp_range.end.character - lsp_range.start.character;
+            encoder.push_token_at(lsp_range.start, len, token.token_type, token.modifiers);
+        }
+    }
+
+    encoder.tokens
+}
+
+// Taken from Ty
+// see: https://github.com/charliermarsh/ruff/blob/5011b253c1aca2a1906762cf45414d0fda1a088a/crates/ty_server/src/server/api/semantic_tokens.rs#L23C25-L23C25
+struct Encoder {
+    tokens: Vec<SemanticToken>,
+    prev_line: u32,
+    prev_start: u32,
+}
+
+impl Encoder {
+    fn push_token_at(
+        &mut self,
+        start: lsp_types::Position,
+        length: u32,
+        ty: SemanticTokenType,
+        _modifiers: Option<SemanticTokenModifier>,
+    ) {
+        // LSP semantic tokens are encoded as deltas
+        let delta_line = start.line - self.prev_line;
+        let delta_start = if delta_line == 0 {
+            start.character - self.prev_start
+        } else {
+            start.character
+        };
+
+        let token_type = to_token_type(ty);
+
+        let token_index = semantic_tokens::type_index(token_type);
+
+        self.tokens.push(SemanticToken {
+            delta_line,
+            delta_start,
+            length,
+            token_type: token_index,
+            // TODO: once we get modifiers going, we'll need to update this
+            token_modifiers_bitset: 0,
+        });
+
+        self.prev_line = start.line;
+        self.prev_start = start.character;
+    }
+}
+
+fn to_token_type(ty: SemanticTokenType) -> lsp_types::SemanticTokenType {
+    match ty {
+        SemanticTokenType::Keyword => lsp_types::SemanticTokenType::KEYWORD,
+        SemanticTokenType::String => lsp_types::SemanticTokenType::STRING,
+        SemanticTokenType::Bool => lsp_types::SemanticTokenType::KEYWORD,
+        SemanticTokenType::Number => lsp_types::SemanticTokenType::NUMBER,
+        SemanticTokenType::Function => lsp_types::SemanticTokenType::FUNCTION,
+        SemanticTokenType::Operator => lsp_types::SemanticTokenType::OPERATOR,
+        SemanticTokenType::Punctuation => lsp_types::SemanticTokenType::OPERATOR,
+        SemanticTokenType::Name => lsp_types::SemanticTokenType::VARIABLE,
+        SemanticTokenType::NameRef => lsp_types::SemanticTokenType::VARIABLE,
+        SemanticTokenType::Comment => lsp_types::SemanticTokenType::COMMENT,
+        SemanticTokenType::Type => lsp_types::SemanticTokenType::TYPE,
+        SemanticTokenType::PositionalParam | SemanticTokenType::Parameter => {
+            lsp_types::SemanticTokenType::PARAMETER
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/squawk_server/src/semantic_tokens.rs
+++ b/crates/squawk_server/src/semantic_tokens.rs
@@ -1,0 +1,26 @@
+use lsp_types::{SemanticTokenModifier, SemanticTokenType};
+
+pub(crate) const SUPPORTED_TYPES: &[SemanticTokenType] = &[
+    SemanticTokenType::COMMENT,
+    SemanticTokenType::FUNCTION,
+    SemanticTokenType::KEYWORD,
+    SemanticTokenType::NAMESPACE,
+    SemanticTokenType::NUMBER,
+    SemanticTokenType::OPERATOR,
+    SemanticTokenType::PARAMETER,
+    SemanticTokenType::PROPERTY,
+    SemanticTokenType::STRING,
+    SemanticTokenType::STRUCT,
+    SemanticTokenType::TYPE,
+    SemanticTokenType::VARIABLE,
+];
+
+pub(crate) const SUPPORTED_MODIFIERS: &[SemanticTokenModifier] = &[
+    SemanticTokenModifier::DECLARATION,
+    SemanticTokenModifier::DEFINITION,
+    SemanticTokenModifier::READONLY,
+];
+
+pub(crate) fn type_index(ty: SemanticTokenType) -> u32 {
+    SUPPORTED_TYPES.iter().position(|it| *it == ty).unwrap() as u32
+}

--- a/crates/squawk_server/src/server.rs
+++ b/crates/squawk_server/src/server.rs
@@ -5,10 +5,15 @@ use lsp_types::{
     CodeActionKind, CodeActionOptions, CodeActionProviderCapability, CompletionOptions,
     DiagnosticOptions, DiagnosticServerCapabilities, FoldingRangeProviderCapability,
     HoverProviderCapability, InitializeParams, OneOf, SelectionRangeProviderCapability,
-    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind, WorkDoneProgressOptions,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, WorkDoneProgressOptions,
 };
 
-use crate::global_state::GlobalState;
+use crate::{
+    global_state::GlobalState,
+    semantic_tokens::{SUPPORTED_MODIFIERS, SUPPORTED_TYPES},
+};
 
 pub fn run() -> Result<()> {
     info!("Starting Squawk LSP server");
@@ -53,6 +58,19 @@ pub fn run() -> Result<()> {
             },
             completion_item: None,
         }),
+        semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
+            SemanticTokensOptions {
+                work_done_progress_options: WorkDoneProgressOptions {
+                    work_done_progress: None,
+                },
+                legend: SemanticTokensLegend {
+                    token_types: SUPPORTED_TYPES.to_vec(),
+                    token_modifiers: SUPPORTED_MODIFIERS.to_vec(),
+                },
+                range: Some(true),
+                full: Some(SemanticTokensFullOptions::Bool(true)),
+            },
+        )),
         ..Default::default()
     })
     .unwrap();

--- a/crates/xtask/src/codegen.rs
+++ b/crates/xtask/src/codegen.rs
@@ -902,7 +902,7 @@ fn generate_nodes(nodes: &[AstNodeSrc], enums: &[AstEnumSrc]) -> String {
 
 // Multi-word keyword phrases that should be highlighted as keywords, not
 // operators.
-const KEYWORD_PHRASES: &[&str] = &["if not exists", "if exists", "or replace"];
+const KEYWORD_PHRASES: &[&str] = &["if not exists", "or replace", "if exists"];
 
 // Multi-word entries must come before their single-word components so the
 // regex engine matches the longest form first.

--- a/crates/xtask/src/codegen.rs
+++ b/crates/xtask/src/codegen.rs
@@ -902,7 +902,7 @@ fn generate_nodes(nodes: &[AstNodeSrc], enums: &[AstEnumSrc]) -> String {
 
 // Multi-word keyword phrases that should be highlighted as keywords, not
 // operators.
-const KEYWORD_PHRASES: &[&str] = &["if not exists", "if exists"];
+const KEYWORD_PHRASES: &[&str] = &["if not exists", "if exists", "or replace"];
 
 // Multi-word entries must come before their single-word components so the
 // regex engine matches the longest form first.

--- a/squawk-vscode/syntaxes/pgsql.tmLanguage.json
+++ b/squawk-vscode/syntaxes/pgsql.tmLanguage.json
@@ -146,7 +146,7 @@
     "keywords": {
       "patterns": [
         {
-          "match": "(?i)\\b(if\\s+not\\s+exists|if\\s+exists)\\b",
+          "match": "(?i)\\b(if\\s+not\\s+exists|if\\s+exists|or\\s+replace)\\b",
           "name": "keyword.other.pgsql"
         },
         {

--- a/squawk-vscode/syntaxes/pgsql.tmLanguage.json
+++ b/squawk-vscode/syntaxes/pgsql.tmLanguage.json
@@ -146,7 +146,7 @@
     "keywords": {
       "patterns": [
         {
-          "match": "(?i)\\b(if\\s+not\\s+exists|if\\s+exists|or\\s+replace)\\b",
+          "match": "(?i)\\b(if\\s+not\\s+exists|or\\s+replace|if\\s+exists)\\b",
           "name": "keyword.other.pgsql"
         },
         {


### PR DESCRIPTION
We're not really doing anything semantic yet, that will come in a follow up PR.
We need to rework goto def so we can easily get the kind when we goto def a given name/name_ref.

With this change, we now properly highlight:

```sql
select 1 and;
select 2 select;
```

`and` and `select` are both column labels in these cases, not keywords.