### PR TITLE
cli: fix missing binary exit code

### DIFF
--- a/js/bin/squawk
+++ b/js/bin/squawk
@@ -42,6 +42,7 @@ const child = childProcess.spawn(binaryPath, process.argv.slice(2), {
 child.on("error", err => {
   console.error("error: failed to invoke squawk")
   console.error(err.stack)
+  process.exit(1)
 })
 
 child.on("exit", code => {


### PR DESCRIPTION
Exit 1 when the npm wrapper fails to spawn the Squawk binary.

This can happen when `squawk-cli` is installed without running its `postinstall` script, so `js/install.js` never downloads `js/binaries/squawk`. For example, pnpm 10 requires dependency build scripts to be approved, Yarn 4.14+ disables third-party postinstalls by default, and npm supports `--ignore-scripts`.

Tested:
- `node --check js/bin/squawk`
- missing binary: `node js/bin/squawk --version` exits 1
- present binary: `node js/bin/squawk --version` exits 0
