### PR TITLE
feat(github): Arg to make the github PR comment cleaner with zero violations.

### DIFF
--- a/crates/squawk/src/config.rs
+++ b/crates/squawk/src/config.rs
@@ -17,6 +17,8 @@ const FILE_NAME: &str = ".squawk.toml";
 pub struct UploadToGitHubConfig {
     #[serde(default)]
     pub fail_on_violations: Option<bool>,
+    #[serde(default)]
+    pub only_comment_on_violations: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -253,6 +255,16 @@ assume_in_transaction = false
         let file = r"
 [upload_to_github]
 fail_on_violations = true        
+        ";
+        fs::write(&squawk_toml, file).expect("Unable to write file");
+        assert_debug_snapshot!(ConfigFile::parse(Some(squawk_toml.path().to_path_buf())));
+    }
+    #[test]
+    fn load_only_comment_on_violations() {
+        let squawk_toml = NamedTempFile::new().expect("generate tempFile");
+        let file = r"
+[upload_to_github]
+only_comment_on_violations = true
         ";
         fs::write(&squawk_toml, file).expect("Unable to write file");
         assert_debug_snapshot!(ConfigFile::parse(Some(squawk_toml.path().to_path_buf())));

--- a/crates/squawk/src/github.rs
+++ b/crates/squawk/src/github.rs
@@ -107,14 +107,13 @@ pub fn check_and_comment_on_pr(cfg: Config) -> Result<()> {
             fail_on_violations
         };
 
-    let only_comment_on_violations =
-        if let Some(only_comment_on_violations_cfg) =
-            cfg.upload_to_github.only_comment_on_violations
-        {
-            only_comment_on_violations_cfg
-        } else {
-            only_comment_on_violations
-        };
+    let only_comment_on_violations = if let Some(only_comment_on_violations_cfg) =
+        cfg.upload_to_github.only_comment_on_violations
+    {
+        only_comment_on_violations_cfg
+    } else {
+        only_comment_on_violations
+    };
 
     let github_app = create_gh_app(
         &github_api_url,
@@ -178,9 +177,7 @@ pub fn check_and_comment_on_pr(cfg: Config) -> Result<()> {
 }
 
 fn get_clean_comment_body(file_count: usize) -> String {
-    format!(
-        "{COMMENT_HEADER}\n\n✅ 0 violations across {file_count} file(s)"
-    )
+    format!("{COMMENT_HEADER}\n\n✅ 0 violations across {file_count} file(s)")
 }
 
 fn get_comment_body(files: &[CheckReport], version: &str) -> String {

--- a/crates/squawk/src/github.rs
+++ b/crates/squawk/src/github.rs
@@ -88,6 +88,7 @@ pub fn check_and_comment_on_pr(cfg: Config) -> Result<()> {
     let UploadToGithubArgs {
         paths,
         fail_on_violations,
+        only_comment_on_violations,
         github_private_key,
         github_api_url,
         github_token,
@@ -104,6 +105,15 @@ pub fn check_and_comment_on_pr(cfg: Config) -> Result<()> {
             fail_on_violations_cfg
         } else {
             fail_on_violations
+        };
+
+    let only_comment_on_violations =
+        if let Some(only_comment_on_violations_cfg) =
+            cfg.upload_to_github.only_comment_on_violations
+        {
+            only_comment_on_violations_cfg
+        } else {
+            only_comment_on_violations
         };
 
     let github_app = create_gh_app(
@@ -133,8 +143,16 @@ pub fn check_and_comment_on_pr(cfg: Config) -> Result<()> {
         info!("no files checked, exiting");
         return Ok(());
     }
-    info!("generating github comment body");
-    let comment_body = get_comment_body(&file_results, VERSION);
+
+    let violations: usize = file_results.iter().map(|f| f.violations.len()).sum();
+
+    let comment_body = if only_comment_on_violations && violations == 0 {
+        info!("no violations found, posting clean summary comment");
+        get_clean_comment_body(file_results.len())
+    } else {
+        info!("generating github comment body");
+        get_comment_body(&file_results, VERSION)
+    };
 
     comment_on_pr(
         github_app.as_ref(),
@@ -151,14 +169,18 @@ pub fn check_and_comment_on_pr(cfg: Config) -> Result<()> {
         fmt_github_annotations(&mut handle, &file_results)?;
     }
 
-    let violations: usize = file_results.iter().map(|f| f.violations.len()).sum();
-
     if fail_on_violations && violations > 0 {
         let files = file_results.len();
         bail!("Found {violations} violation(s) across {files} file(s)");
     }
 
     Ok(())
+}
+
+fn get_clean_comment_body(file_count: usize) -> String {
+    format!(
+        "{COMMENT_HEADER}\n\n✅ 0 violations across {file_count} file(s)"
+    )
 }
 
 fn get_comment_body(files: &[CheckReport], version: &str) -> String {
@@ -425,6 +447,12 @@ ALTER TABLE "core_recipe" ADD COLUMN "foo" integer DEFAULT 10;
 
         let body = get_comment_body(&violations, "0.2.3");
 
+        assert_snapshot!(body);
+    }
+
+    #[test]
+    fn generating_clean_comment_no_violations() {
+        let body = super::get_clean_comment_body(8);
         assert_snapshot!(body);
     }
 

--- a/crates/squawk/src/main.rs
+++ b/crates/squawk/src/main.rs
@@ -26,6 +26,9 @@ pub struct UploadToGithubArgs {
     /// Exits with an error if violations are found
     #[arg(long)]
     fail_on_violations: bool,
+    /// Only posts a report comment on violations
+    #[arg(long)]
+    only_comment_on_violations: bool,
     #[arg(long, env = "SQUAWK_GITHUB_PRIVATE_KEY")]
     github_private_key: Option<String>,
     #[arg(long, env = "SQUAWK_GITHUB_PRIVATE_KEY_BASE64")]

--- a/crates/squawk/src/snapshots/squawk__config__test_config__load_assume_in_transaction.snap
+++ b/crates/squawk/src/snapshots/squawk__config__test_config__load_assume_in_transaction.snap
@@ -14,6 +14,7 @@ Ok(
             ),
             upload_to_github: UploadToGitHubConfig {
                 fail_on_violations: None,
+                only_comment_on_violations: None,
             },
         },
     ),

--- a/crates/squawk/src/snapshots/squawk__config__test_config__load_cfg_full.snap
+++ b/crates/squawk/src/snapshots/squawk__config__test_config__load_cfg_full.snap
@@ -26,6 +26,7 @@ Ok(
             ),
             upload_to_github: UploadToGitHubConfig {
                 fail_on_violations: None,
+                only_comment_on_violations: None,
             },
         },
     ),

--- a/crates/squawk/src/snapshots/squawk__config__test_config__load_excluded_paths.snap
+++ b/crates/squawk/src/snapshots/squawk__config__test_config__load_excluded_paths.snap
@@ -14,6 +14,7 @@ Ok(
             assume_in_transaction: None,
             upload_to_github: UploadToGitHubConfig {
                 fail_on_violations: None,
+                only_comment_on_violations: None,
             },
         },
     ),

--- a/crates/squawk/src/snapshots/squawk__config__test_config__load_excluded_rules_with_alias.snap
+++ b/crates/squawk/src/snapshots/squawk__config__test_config__load_excluded_rules_with_alias.snap
@@ -15,6 +15,7 @@ Ok(
             assume_in_transaction: None,
             upload_to_github: UploadToGitHubConfig {
                 fail_on_violations: None,
+                only_comment_on_violations: None,
             },
         },
     ),

--- a/crates/squawk/src/snapshots/squawk__config__test_config__load_fail_on_violations.snap
+++ b/crates/squawk/src/snapshots/squawk__config__test_config__load_fail_on_violations.snap
@@ -14,6 +14,7 @@ Ok(
                 fail_on_violations: Some(
                     true,
                 ),
+                only_comment_on_violations: None,
             },
         },
     ),

--- a/crates/squawk/src/snapshots/squawk__config__test_config__load_included_rules.snap
+++ b/crates/squawk/src/snapshots/squawk__config__test_config__load_included_rules.snap
@@ -14,6 +14,7 @@ Ok(
             assume_in_transaction: None,
             upload_to_github: UploadToGitHubConfig {
                 fail_on_violations: None,
+                only_comment_on_violations: None,
             },
         },
     ),

--- a/crates/squawk/src/snapshots/squawk__config__test_config__load_only_comment_on_violations.snap
+++ b/crates/squawk/src/snapshots/squawk__config__test_config__load_only_comment_on_violations.snap
@@ -6,15 +6,15 @@ Ok(
     Some(
         ConfigFile {
             excluded_paths: [],
-            excluded_rules: [
-                RequireConcurrentIndexCreation,
-            ],
+            excluded_rules: [],
             included_rules: [],
             pg_version: None,
             assume_in_transaction: None,
             upload_to_github: UploadToGitHubConfig {
                 fail_on_violations: None,
-                only_comment_on_violations: None,
+                only_comment_on_violations: Some(
+                    true,
+                ),
             },
         },
     ),

--- a/crates/squawk/src/snapshots/squawk__config__test_config__load_pg_version.snap
+++ b/crates/squawk/src/snapshots/squawk__config__test_config__load_pg_version.snap
@@ -20,6 +20,7 @@ Ok(
             assume_in_transaction: None,
             upload_to_github: UploadToGitHubConfig {
                 fail_on_violations: None,
+                only_comment_on_violations: None,
             },
         },
     ),

--- a/crates/squawk/src/snapshots/squawk__github__test_github_comment__generating_clean_comment_no_violations.snap
+++ b/crates/squawk/src/snapshots/squawk__github__test_github_comment__generating_clean_comment_no_violations.snap
@@ -1,0 +1,7 @@
+---
+source: crates/squawk/src/github.rs
+expression: body
+---
+# Squawk Report
+
+✅ 0 violations across 8 file(s)

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -149,6 +149,7 @@ excluded_paths = [
 ]
 [upload_to_github]
 fail_on_violations = true
+only_comment_on_violations = true
 ```
 
 See the [Squawk website](https://squawkhq.com/docs/rules) for documentation on each rule with examples and reasoning.

--- a/docs/docs/github_app.md
+++ b/docs/docs/github_app.md
@@ -161,3 +161,23 @@ To use Squawk as a GitHub App, Squawk needs a corresponding GitHub App so it can
 
    <https://github.com/sbdchd/squawk/pull/14#issuecomment-647009446>
 
+## Only comment on violations
+
+By default, Squawk posts a PR comment on every run. To suppress the full report
+when there are no violations, pass `--only-comment-on-violations` to the
+`upload-to-github` subcommand:
+
+```bash
+squawk upload-to-github --only-comment-on-violations example.sql
+```
+
+Or set it in `.squawk.toml`:
+
+```toml
+[upload_to_github]
+only_comment_on_violations = true
+```
+
+When no violations are found, Squawk will post a brief ✅ summary instead of
+the full report.
+


### PR DESCRIPTION
When enabled this should just post a report that looks like this

<img width="913" height="185" alt="image" src="https://github.com/user-attachments/assets/087e6856-53f4-4fff-bb64-957d0666d20e" />


Without this we are getting lots of extra comments about sqlfiles that do not report an issue which fills up space in the PR.

<img width="884" height="1287" alt="image" src="https://github.com/user-attachments/assets/139d6f6f-bceb-41e3-b648-05682f9401a8" />


This PR could also be adjusted to not have a new argument and just have this behavior by default if desired.

Thank you.