### PR TITLE
ci: stop injecting optional dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -237,14 +237,6 @@ jobs:
           cp artifacts/release-squawk-windows-x64.exe/squawk-windows-x64.exe npm/win32-x64/bin/squawk.exe
           chmod +x npm/darwin-x64/bin/squawk npm/darwin-arm64/bin/squawk npm/linux-x64/bin/squawk npm/linux-arm64/bin/squawk
 
-      - name: Inject optionalDependencies into root package.json
-        run: |
-          set -euo pipefail
-          VERSION=$(node -p 'require("./package.json").version')
-          for tgt in darwin-x64 darwin-arm64 linux-x64 linux-arm64 win32-x64; do
-            npm pkg set "optionalDependencies.@squawk-cli/${tgt}=${VERSION}"
-          done
-
       - name: Publish packages
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ to your project's `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/sbdchd/squawk
-    rev: 2.55.0
+    rev: v2.55.0
     hooks:
       - id: squawk
         files: path/to/postgres/migrations/written/in/sql

--- a/crates/xtask/src/update_version.rs
+++ b/crates/xtask/src/update_version.rs
@@ -138,7 +138,7 @@ fn update_versions(sh: &Shell, v: &str) -> Result<()> {
         r#"const SQUAWK_USER_AGENT: &str = "squawk/.*""#,
         &format!(r#"const SQUAWK_USER_AGENT: &str = "squawk/{v}""#),
     )?;
-    replace_in_file(sh, "README.md", "rev: .*", &format!("rev: {v}"))?;
+    replace_in_file(sh, "README.md", "rev: .*", &format!("rev: v{v}"))?;
 
     Ok(())
 }

--- a/crates/xtask/src/update_version.rs
+++ b/crates/xtask/src/update_version.rs
@@ -101,6 +101,12 @@ fn update_versions(sh: &Shell, v: &str) -> Result<()> {
     replace_in_file(sh, "package.json", r#""version": ".*""#, &json_rep)?;
     replace_in_file(
         sh,
+        "package.json",
+        r#"("@squawk-cli/[^"]+": ")[^"]+""#,
+        &format!(r#"${{1}}{v}""#),
+    )?;
+    replace_in_file(
+        sh,
         "squawk-vscode/package.json",
         r#""version": ".*""#,
         &json_rep,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,13 @@
     "oxfmt": "^0.44.0",
     "typescript": "^3.9.5"
   },
+  "optionalDependencies": {
+    "@squawk-cli/darwin-arm64": "2.55.0",
+    "@squawk-cli/darwin-x64": "2.55.0",
+    "@squawk-cli/linux-arm64": "2.55.0",
+    "@squawk-cli/linux-x64": "2.55.0",
+    "@squawk-cli/win32-x64": "2.55.0"
+  },
   "volta": {
     "node": "20.19.0",
     "pnpm": "9.15.4"

--- a/package.json
+++ b/package.json
@@ -39,5 +39,14 @@
     "node": "20.19.0",
     "pnpm": "9.15.4"
   },
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@9.15.4",
+  "pnpm": {
+    "ignoredOptionalDependencies": [
+      "@squawk-cli/darwin-arm64",
+      "@squawk-cli/darwin-x64",
+      "@squawk-cli/linux-arm64",
+      "@squawk-cli/linux-x64",
+      "@squawk-cli/win32-x64"
+    ]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1134,6 +1134,13 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+ignoredOptionalDependencies:
+  - '@squawk-cli/darwin-arm64'
+  - '@squawk-cli/darwin-x64'
+  - '@squawk-cli/linux-arm64'
+  - '@squawk-cli/linux-x64'
+  - '@squawk-cli/win32-x64'
+
 snapshots:
 
   '@babel/code-frame@7.12.11':


### PR DESCRIPTION
now that they're published, I think we can just bump them as part of the release, hopefully.


rel: https://github.com/sbdchd/squawk/issues/1178