### PR TITLE
require-timeout-settings: explain lock impact in the warning

### DIFF
--- a/crates/squawk_linter/src/rules/require_timeout_settings.rs
+++ b/crates/squawk_linter/src/rules/require_timeout_settings.rs
@@ -39,6 +39,55 @@ enum ReportOnce {
     Reported,
 }
 
+/// The lock a statement takes. `Unknown` covers statements we don't have a
+/// specific note for; more get added over time (e.g. the ACCESS EXCLUSIVE
+/// `ALTER TABLE` variants).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LockMode {
+    Unknown,
+    ShareUpdateExclusive,
+}
+
+impl LockMode {
+    /// The lock's name, or `None` when we can't classify the statement.
+    fn name(self) -> Option<&'static str> {
+        match self {
+            LockMode::Unknown => None,
+            LockMode::ShareUpdateExclusive => Some("SHARE UPDATE EXCLUSIVE"),
+        }
+    }
+
+    /// The warning message, naming the lock when we can classify it.
+    fn violation_message(self) -> String {
+        match self.name() {
+            Some(name) => {
+                format!("Missing `set lock_timeout` before potentially slow {name} lock operations")
+            }
+            None => "Missing `set lock_timeout` before potentially slow operations".to_string(),
+        }
+    }
+
+    /// The `lock_timeout` help text, ending with what this lock does and doesn't
+    /// block so a reader can judge how much the timeout matters.
+    fn help(self) -> &'static str {
+        match self {
+            LockMode::Unknown => "Configure a `lock_timeout` before this statement.",
+            LockMode::ShareUpdateExclusive => {
+                "Configure a `lock_timeout` before this statement. It takes a SHARE UPDATE \
+                 EXCLUSIVE lock. It will block other schema changes (VACUUM, ANALYZE, index \
+                 builds) but not reads or writes."
+            }
+        }
+    }
+}
+
+fn statement_lock(stmt: &ast::Stmt) -> LockMode {
+    match stmt {
+        ast::Stmt::CommentOn(_) => LockMode::ShareUpdateExclusive,
+        _ => LockMode::Unknown,
+    }
+}
+
 pub(crate) fn require_timeout_settings(ctx: &mut Linter, parse: &Parse<SourceFile>) {
     let file = parse.tree();
 
@@ -71,15 +120,15 @@ pub(crate) fn require_timeout_settings(ctx: &mut Linter, parse: &Parse<SourceFil
                 }
             }
             _ if analyze::possibly_slow_stmt(&stmt) => {
+                let lock = statement_lock(&stmt);
                 if lock_timeout == ReportOnce::Missing {
                     ctx.report(
                         Violation::for_node(
                             Rule::RequireTimeoutSettings,
-                            "Missing `set lock_timeout` before potentially slow operations"
-                                .to_string(),
+                            lock.violation_message(),
                             stmt.syntax(),
                         )
-                        .help("Configure a `lock_timeout` before this statement.".to_string())
+                        .help(lock.help().to_string())
                         .fix(create_lock_timeout_fix(&file)),
                     );
                     lock_timeout = ReportOnce::Reported;
@@ -292,6 +341,20 @@ CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');
         2 + set statement_timeout = '5s';
           ╰╴
         ");
+    }
+
+    #[test]
+    fn err_comment_on_explains_lock_impact() {
+        // COMMENT ON takes a SHARE UPDATE EXCLUSIVE lock, so the help should
+        // name the lock mode.
+        let sql = r#"
+COMMENT ON COLUMN t.c IS 'an opaque id';
+        "#;
+        let out = lint_errors(sql, Rule::RequireTimeoutSettings);
+        assert!(
+            out.contains("EXCLUSIVE"),
+            "expected the lock mode to appear in the help text, got:\n{out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`require-timeout-settings` fires on any statement that can wait on a lock, but the message never says which lock the statement takes or what it conflicts with. That flattens a real distinction: `ALTER TABLE ... ADD COLUMN` takes an ACCESS EXCLUSIVE lock that blocks reads and writes, while `COMMENT ON` takes a SHARE UPDATE EXCLUSIVE lock that blocks neither — it only contends with VACUUM/ANALYZE/index builds. Same generic message today, so a reader can't tell a potential outage from a catalog write that's effectively free.

## What this changes

Classifies statements by the Postgres lock mode they take, then names that lock in the warning and uses it to build the `lock_timeout` help, so both are keyed off the lock level rather than the statement.

The model is small: a `LockMode` enum with `name()` (used to build `violation_message()`) and `help()`, plus `statement_lock(&stmt) -> LockMode` for the classification. This PR wires up `SHARE UPDATE EXCLUSIVE` (via `COMMENT ON`); everything else maps to `LockMode::Unknown`, whose `name()` is `None` so the message and help fall back to the original generic text — so every other message and snapshot is unchanged. Same statements are flagged.

## Extending

Adding a lock class is a new `LockMode` variant plus its `name()`/`help()` arms, and the statements that map to it in `statement_lock`. The notable gap is the ACCESS EXCLUSIVE `ALTER TABLE` variants: their lock depends on the per-action subcommand (`ADD COLUMN` vs `VALIDATE CONSTRAINT` vs `SET STATISTICS`…), so classifying them means descending into `alter_table.actions()` rather than matching at the `Stmt` level. Left for a follow-up to keep this reviewable.

## Example

```
warning[require-timeout-settings]: Missing `set lock_timeout` before potentially slow SHARE UPDATE EXCLUSIVE lock operations
 ╭▸ comment.sql:1:1
 │
1│ COMMENT ON COLUMN t.c IS 'an opaque id';
 │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 │
 ├ help: Configure a `lock_timeout` before this statement. It takes a SHARE UPDATE EXCLUSIVE lock. It will block other schema changes (VACUUM, ANALYZE, index builds) but not reads or writes.
```

## Testing

Existing snapshots unchanged; adds `err_comment_on_explains_lock_impact`, which asserts the `COMMENT ON` help includes the lock mode (`contains("EXCLUSIVE")` rather than a snapshot, so it's robust to help-text wrapping).
