### PR TITLE
linter: fix splitting into lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
  "itertools",
  "rowan",
  "squawk-lexer",
+ "squawk-line-index",
  "squawk-syntax",
  "tiny_pretty",
 ]
@@ -3486,6 +3487,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
+ "squawk-line-index",
  "toml",
  "ungrammar",
  "xshell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ manual_let_else = "deny"
 explicit_iter_loop = "deny"
 too_many_arguments = "allow"
 disallowed_types = "deny"
+disallowed_methods = "deny"
 uninlined_format_args = "deny"
 
 [profile.dev]

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,3 +2,7 @@ disallowed-types = [
   { path = "std::collections::HashMap", reason = "Use rustc_hash::FxHashMap instead" },
   { path = "std::collections::HashSet", reason = "Use rustc_hash::FxHashSet instead" },
 ]
+
+disallowed-methods = [
+  { path = "str::lines", reason = "Use squawk_line_index::UniversalNewlines::universal_newlines instead, `str::lines` doesn't handle CR line endings" },
+]

--- a/crates/squawk/src/github.rs
+++ b/crates/squawk/src/github.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use console::strip_ansi_codes;
 use log::info;
 use squawk_github::{GitHubApi, actions, app, comment_on_pr};
+use squawk_line_index::UniversalNewlines;
 use std::io;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -201,7 +202,7 @@ fn get_summary_comment_body(
     for file in files {
         let violation_count = file.violations.len();
         let violations_emoji = get_violations_emoji(violation_count);
-        let line_count = file.sql.lines().count();
+        let line_count = file.sql.universal_newlines().count();
 
         let summary = format!(
             r"
@@ -281,7 +282,7 @@ fn format_comment(
 }
 
 fn truncate_sql_if_needed(sql: &str) -> (String, bool) {
-    let lines: Vec<&str> = sql.lines().collect();
+    let lines: Vec<&str> = sql.universal_newlines().collect();
     if lines.len() <= MAX_SQL_PREVIEW_LINES {
         (sql.to_string(), false)
     } else {

--- a/crates/squawk_fmt/Cargo.toml
+++ b/crates/squawk_fmt/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/main.rs"
 tiny_pretty.workspace = true
 itertools.workspace = true
 squawk-syntax.workspace = true
+squawk-line-index.workspace = true
 rowan.workspace = true
 clap.workspace = true
 anyhow.workspace = true

--- a/crates/squawk_fmt/src/fmt.rs
+++ b/crates/squawk_fmt/src/fmt.rs
@@ -1,10 +1,12 @@
+use anyhow::{Result, bail};
 use itertools::Itertools;
 use rowan::Direction;
+use squawk_line_index::{LineEnding, UniversalNewlines, find_newline};
 use squawk_syntax::ast::{self, AstNode, LitKind};
 use squawk_syntax::quote::quote_column_alias;
 use squawk_syntax::{SyntaxKind, SyntaxNode, SyntaxToken};
 use tiny_pretty::Doc;
-use tiny_pretty::{PrintOptions, print};
+use tiny_pretty::{LineBreak, PrintOptions, print};
 
 // TODO: anytime we have `syntax().to_string()`, it means we have to do more to
 // actually convert the data into the IR. to_string() is a temp hack
@@ -31,7 +33,7 @@ fn build_source_file(source_file: &ast::SourceFile) -> Doc<'_> {
                     doc = doc.append(Doc::text(token.text().to_string()));
                 } else if token.kind() == SyntaxKind::WHITESPACE {
                     // TODO: I think we can improve this
-                    let lines = token.text().lines().count();
+                    let lines = token.text().universal_newlines().count();
                     if lines >= 2 {
                         doc = doc.append(Doc::empty_line()).append(Doc::empty_line());
                     } else {
@@ -645,18 +647,32 @@ fn build_target<'a>(target: ast::Target) -> Option<Doc<'a>> {
     Some(doc)
 }
 
-pub fn fmt(text: &str) -> String {
+pub fn fmt(text: &str) -> Result<String> {
+    let line_ending = find_newline(text)
+        .map(|(_, ending)| ending)
+        .unwrap_or_default();
+
+    let line_break = match line_ending {
+        // see: https://github.com/g-plane/tiny_pretty/issues/3
+        LineEnding::Cr => bail!("CR line endings aren't supported"),
+        LineEnding::CrLf => LineBreak::Crlf,
+        LineEnding::Lf => LineBreak::Lf,
+    };
+
     let parse = ast::SourceFile::parse(text);
     let file = parse.tree();
-    println!("{text}");
-    println!("---");
-    println!("{:#?}", file.syntax());
-    println!("---");
     debug_assert_eq!(
         parse.errors(),
         vec![],
         "should bail out when there's parse errors"
     );
     let doc = build_source_file(&file);
-    print(&doc, &PrintOptions::default())
+
+    Ok(print(
+        &doc,
+        &PrintOptions {
+            line_break,
+            ..Default::default()
+        },
+    ))
 }

--- a/crates/squawk_fmt/src/main.rs
+++ b/crates/squawk_fmt/src/main.rs
@@ -23,6 +23,6 @@ fn main() -> Result<()> {
         }
     };
 
-    print!("{}", squawk_fmt::fmt(&input));
+    print!("{}", squawk_fmt::fmt(&input)?);
     Ok(())
 }

--- a/crates/squawk_fmt/tests/tests.rs
+++ b/crates/squawk_fmt/tests/tests.rs
@@ -15,7 +15,7 @@ fn fmt(fixture: Fixture<&str>) {
         .and_then(|x| x.strip_suffix(".sql"))
         .unwrap();
 
-    let formatted = squawk_fmt::fmt(content);
+    let formatted = squawk_fmt::fmt(content).unwrap();
 
     assert_no_dropped_tokens(content, &formatted);
 
@@ -27,6 +27,63 @@ fn fmt(fixture: Fixture<&str>) {
     }, {
         assert_snapshot!(test_name, formatted);
     });
+}
+
+fn fmt_with_line_ending(line_ending: &str) -> String {
+    let sql = [
+        "-- a comment",
+        "select 1;",
+        "",
+        "/* a comment",
+        " * spanning lines",
+        " */",
+        "select  'a',  'really long string                                                    ';",
+        "",
+    ]
+    .join(line_ending);
+
+    match squawk_fmt::fmt(&sql) {
+        Ok(formatted) => {
+            assert_no_dropped_tokens(&sql, &formatted);
+            formatted.replace('\r', "<CR>")
+        }
+        Err(err) => format!("error: {err}"),
+    }
+}
+
+#[test]
+fn fmt_lf_line_endings() {
+    assert_snapshot!(fmt_with_line_ending("\n"), @"
+    -- a comment
+    select 1;
+
+    /* a comment
+     * spanning lines
+     */
+    select
+      'a',
+      'really long string                                                    ';
+    ");
+}
+
+#[test]
+fn fmt_crlf_line_endings() {
+    assert_snapshot!(fmt_with_line_ending("\r\n"), @"
+    -- a comment<CR>
+    select 1;<CR>
+    <CR>
+    /* a comment<CR>
+     * spanning lines<CR>
+     */<CR>
+    select<CR>
+      'a',<CR>
+      'really long string                                                    ';<CR>
+    ");
+}
+
+#[test]
+fn fmt_cr_line_endings() {
+    assert_snapshot!(fmt_with_line_ending("\r"), @"error: CR line endings aren't supported");
 }
 
 fn meaningful_tokens(text: &str) -> Vec<(TokenKind, &str)> {

--- a/crates/squawk_ide/src/comments.rs
+++ b/crates/squawk_ide/src/comments.rs
@@ -1,4 +1,5 @@
 use rowan::{Direction, NodeOrToken};
+use squawk_line_index::UniversalNewlines;
 use squawk_syntax::{
     SyntaxNode,
     ast::{self, AstToken},
@@ -54,7 +55,7 @@ fn normalize_comment(comment: &str) -> String {
         .and_then(|comment| comment.strip_suffix("*/"))
     {
         let normalized = comment
-            .lines()
+            .universal_newlines()
             .map(|line| line.trim_start().trim_start_matches('*').trim_start())
             .collect::<Vec<_>>()
             .join("\n");

--- a/crates/squawk_line_index/src/lib.rs
+++ b/crates/squawk_line_index/src/lib.rs
@@ -15,7 +15,7 @@ mod tests;
 
 use nohash_hasher::IntMap;
 
-pub use local::{LineEnding, find_newline};
+pub use local::{LineEnding, UniversalNewlineIterator, UniversalNewlines, find_newline};
 pub use text_size::{TextRange, TextSize};
 
 /// `(line, column)` information in the native, UTF-8 encoding.

--- a/crates/squawk_line_index/src/local.rs
+++ b/crates/squawk_line_index/src/local.rs
@@ -1,6 +1,8 @@
 //! Changes mostly ported from Ruff that aren't part of upstream `line_index` crate in Rust Analyzer
 #![allow(missing_docs)]
 
+use std::iter::FusedIterator;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LineEnding {
     /// Classic Mac, `\r`.
@@ -32,6 +34,7 @@ impl LineEnding {
 }
 
 /// Finds the next newline character. Returns its position and the [`LineEnding`].
+// via: https://github.com/astral-sh/ruff/blob/2742f956d87314cf1522c69c9a95a71d972bd76c/crates/ruff_source_file/src/newlines.rs#L58
 #[inline]
 pub fn find_newline(text: &str) -> Option<(usize, LineEnding)> {
     let bytes = text.as_bytes();
@@ -45,9 +48,54 @@ pub fn find_newline(text: &str) -> Option<(usize, LineEnding)> {
     Some((position, line_ending))
 }
 
+// via: https://github.com/astral-sh/ruff/blob/2742f956d87314cf1522c69c9a95a71d972bd76c/crates/ruff_source_file/src/newlines.rs#L7
+/// Extension trait for [`str`] that provides a [`UniversalNewlineIterator`].
+pub trait UniversalNewlines {
+    fn universal_newlines(&self) -> UniversalNewlineIterator<'_>;
+}
+
+impl UniversalNewlines for str {
+    fn universal_newlines(&self) -> UniversalNewlineIterator<'_> {
+        UniversalNewlineIterator::new(self)
+    }
+}
+
+/// Like [`str::lines`], but accommodates LF, CRLF, and CR line endings,
+/// the latter of which are not supported by [`str::lines`].
+#[derive(Debug, Clone)]
+pub struct UniversalNewlineIterator<'a> {
+    text: &'a str,
+}
+
+impl<'a> UniversalNewlineIterator<'a> {
+    pub fn new(text: &'a str) -> UniversalNewlineIterator<'a> {
+        UniversalNewlineIterator { text }
+    }
+}
+
+impl<'a> Iterator for UniversalNewlineIterator<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<&'a str> {
+        if self.text.is_empty() {
+            return None;
+        }
+        match find_newline(self.text) {
+            Some((position, line_ending)) => {
+                let line = &self.text[..position];
+                self.text = &self.text[position + line_ending.as_str().len()..];
+                Some(line)
+            }
+            None => Some(std::mem::take(&mut self.text)),
+        }
+    }
+}
+
+impl FusedIterator for UniversalNewlineIterator<'_> {}
+
 #[cfg(test)]
 mod tests {
-    use super::{LineEnding, find_newline};
+    use super::{LineEnding, UniversalNewlines, find_newline};
 
     #[test]
     fn finding_the_newline() {
@@ -77,6 +125,28 @@ mod tests {
     }
 
     #[test]
+    fn universal_newlines_matches_str_lines() {
+        let lines = |text: &'static str| text.universal_newlines().collect::<Vec<_>>();
+
+        assert_eq!(lines(""), Vec::<&str>::new());
+        assert_eq!(lines("a"), vec!["a"]);
+        assert_eq!(lines("a\nb"), vec!["a", "b"]);
+        assert_eq!(lines("a\r\nb"), vec!["a", "b"]);
+
+        // `str::lines` doesn't support `\r`
+        assert_eq!(lines("a\rb"), vec!["a", "b"]);
+        assert_eq!(lines("a\rb\r\nc\nd"), vec!["a", "b", "c", "d"]);
+
+        // trailing new lines
+        assert_eq!(lines("a\n"), vec!["a"]);
+        assert_eq!(lines("a\r\n"), vec!["a"]);
+        assert_eq!(lines("a\r"), vec!["a"]);
+
+        assert_eq!(lines("a\n\nb"), vec!["a", "", "b"]);
+        assert_eq!(lines("\n"), vec![""]);
+    }
+
+    #[test]
     fn newline_type_default() {
         let detect = |text| {
             find_newline(text)
@@ -86,7 +156,7 @@ mod tests {
 
         assert_eq!(detect("select 1;"), LineEnding::default());
         assert_eq!(detect(""), LineEnding::default());
-        // anything with a break is detected, never defaulted
+
         assert_eq!(detect("select 1;\n"), LineEnding::Lf);
         assert_eq!(detect("select 1;\r\n"), LineEnding::CrLf);
         assert_eq!(detect("select 1;\r"), LineEnding::Cr);

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -26,6 +26,7 @@ xshell.workspace = true
 proc-macro2.workspace = true
 regex.workspace = true
 rustc-hash.workspace = true
+squawk-line-index.workspace = true
 
 [lints]
 workspace = true

--- a/crates/xtask/src/keywords.rs
+++ b/crates/xtask/src/keywords.rs
@@ -2,6 +2,7 @@ use crate::path::project_root;
 use anyhow::{Context, Ok, Result};
 use enum_iterator::{Sequence, all};
 use rustc_hash::{FxHashMap, FxHashSet};
+use squawk_line_index::UniversalNewlines;
 
 struct KeywordMeta {
     pub(crate) category: KeywordCategory,
@@ -80,7 +81,7 @@ fn parse_header() -> Result<FxHashMap<String, KeywordMeta>> {
 
     let mut keywords = FxHashMap::default();
 
-    for line in data.lines() {
+    for line in data.universal_newlines() {
         if line.starts_with("PG_KEYWORD") {
             let line = line
                 .split(&['(', ')'])

--- a/crates/xtask/src/update_version.rs
+++ b/crates/xtask/src/update_version.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result, bail};
 use clap::Args;
 use jiff::Zoned;
 use regex::Regex;
+use squawk_line_index::UniversalNewlines;
 use xshell::{Shell, cmd};
 
 use crate::path::project_root;
@@ -42,7 +43,7 @@ pub(crate) fn update_version(args: UpdateVersionArgs) -> Result<()> {
 
     let tags = cmd!(sh, "git tag --sort=-version:refname").read()?;
     let latest_tag = tags
-        .lines()
+        .universal_newlines()
         .next()
         .filter(|t| !t.is_empty())
         .context("No previous git tag found")?;


### PR DESCRIPTION
rel: https://github.com/g-plane/tiny_pretty/issues/3